### PR TITLE
Move closer to the original code

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -21,7 +21,7 @@ var (
 	DefaultBondDenom = "stake"
 
 	// DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
-	DefaultPowerReduction = sdkmath.NewIntFromUint64(1000000)
+	DefaultPowerReduction = sdkmath.NewIntFromUint64(1)
 )
 
 // TokensToConsensusPower - convert input tokens to potential consensus-engine power

--- a/x/staking/keeper/abci.go
+++ b/x/staking/keeper/abci.go
@@ -2,8 +2,6 @@ package keeper
 
 import (
 	"context"
-	"cosmossdk.io/math"
-
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -20,19 +18,5 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 // EndBlocker called at every block, update validator set
 func (k *Keeper) EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, telemetry.Now(), telemetry.MetricKeyEndBlocker)
-	allValidators, err := k.GetAllValidators(ctx)
-	if err != nil {
-		return nil, err
-	}
-	updates := make([]abci.ValidatorUpdate, 0, len(allValidators))
-	for _, validator := range allValidators {
-		update := validator.ABCIValidatorUpdate(math.NewInt(1))
-		if update.Power == 0 {
-			k.Logger(ctx).Info("Validator has no power, skipping update", "validator", update)
-			continue
-		}
-		updates = append(updates, update)
-		k.Logger(ctx).Info("UpdateValidator:", "pubKey", update.PubKey, "power", update.Power)
-	}
-	return updates, nil
+	return k.BlockValidatorUpdates(ctx)
 }


### PR DESCRIPTION
When we initially did this, we didn't know much. Now we know more, so let's fix things the right way. Effectively, we revert to the original behavior, which handles zero power validators and validator power changes in general far better. To do so, 3 adjustments:
1. Change "PowerReduction" to 1. This means ANY small amount of tokens will count as Power. Otherwise we have no validators, as the scale of compute power is too small.
2. Remove moving tokens into the bonded account. Since our tokens are merely stand-ins for compute power, not actual coin, the coin may not be available (breaking consensus)
3. When we set power in `compute.go`, make sure to delete the old PowerIndex entry, and make sure to add a new one. Without this, the original code fails to update CometBFT correctly.

And that's all! A little logging here and there for now, but we have reduced complexity while making sure compute power is rightly represented in CometBFT consensus.

