### PR TITLE
fix(slashing): Re-enable downtime slashing and hooks

### DIFF
--- a/gonka/ecies/README.md
+++ b/gonka/ecies/README.md
@@ -1,0 +1,17 @@
+# ECIES Encryption Integration
+
+This change integrates ECIES (Elliptic Curve Integrated Encryption Scheme) with the Cosmos SDK keyring, using an implementation based on the Go Ethereum (Geth) library.
+
+## Core Changes
+
+1.  **New `crypto/ecies` Package**: A new package, `crypto/ecies`, has been added to the SDK. This package contains the core logic for ECIES encryption and decryption. It is a direct adaptation of the ECIES implementation found in Ethereum's Go client.
+
+2.  **Keyring Integration (`crypto/keyring/keyring.go`)**: The main `keystore` was updated to support ECIES operations directly.
+    *   A new `ECIESCrypto` interface has been defined and implemented, exposing `Encrypt`, `EncryptByAddress`, `Decrypt`, and `DecryptByAddress` methods.
+    *   To make Cosmos SDK's `secp256k1` keys compatible with the standard cryptographic library used by the ECIES implementation, helper functions (`cosmosPrivKeyToECDSA` and `cosmosPubKeyToECDSA`) were introduced. These functions use the `decred/dcrd/dcrec/secp256k1` library to convert Cosmos keys into the standard `ecdsa` key format.
+
+## Functional Details
+
+The integration enables encrypting data with a recipient's public key, ensuring only the recipient can decrypt it with their private key.
+
+This functionality is exposed through the keyring, allowing developers to perform ECIES operations using familiar key identifiers (`uid`) or addresses. The implementation handles the necessary key format conversions seamlessly in the background. This provides a robust layer of security for sensitive data that needs to be stored or transmitted. 

--- a/gonka/staking/README.md
+++ b/gonka/staking/README.md
@@ -1,0 +1,31 @@
+# Staking, Compute, and Slashing Module Changes
+
+This set of changes introduces a significant overhaul of the `x/staking` module to disconnect it from real tokenomics. The primary goal is to base validator consensus power on an external "Proof of Compute" (PoC) metric, rather than on bonded tokens. This involves fundamental changes to staking, slashing, and bank logic.
+
+## Key Changes
+
+### 1. Staking Logic Override & "Compute Power"
+
+A new system based on "compute power" has been introduced, completely overriding the standard token-bonding staking logic.
+
+- **`x/staking/keeper/compute.go`**: This new file introduces `SetComputeValidators`, which is the primary entry point for managing the validator set. It takes a list of `ComputeResult` objects (containing a public key and power) and reconciles it with the current validator set.
+- **No Token Bonding**: The traditional mechanism of bonding tokens is entirely bypassed.
+  - In `x/staking/keeper/delegation.go`, the `Delegate` function now includes a check (`validator.Description.Details != "Created after Proof of Compute"`) to avoid moving tokens for these new compute-based validators.
+  - In `x/staking/keeper/val_state_change.go`, the logic to transfer tokens between the `bonded` and `not-bonded` pools has been removed.
+- **Manual `TotalBondedTokens`**: The `TotalBondedTokens` function in `x/staking/keeper/pool.go` no longer checks the bank module's balance. Instead, it manually iterates through all validators and sums their `Tokens` field to calculate the total bonded power.
+
+### 2. Power Calculation and Validator Updates
+
+- **`DefaultPowerReduction`**: This parameter in `types/staking.go` has been changed from `1,000,000` to `1`. This makes it so that any non-zero amount of tokens (representing compute power) translates to consensus power, accommodating a different power scale.
+- **Validator Power Indexing**: Logic in `x/staking/keeper/compute.go` now correctly manages the power index by explicitly calling `DeleteValidatorByPowerIndex` before setting the new power and calling `SetValidatorByPowerIndex`. This addresses issues with validator power updates in CometBFT.
+
+### 3. Slashing Mechanism Modified for Safe Hook Triggering
+
+- **Staking Module Made Safe**: The core `Slash` function in `x/staking/keeper/slash.go` has been modified to no longer burn tokens. Its purpose is now to reduce a validator's abstract "compute power" and to trigger hooks for other modules.
+- **Safe Hook Mechanism**: This two-part change ensures that when a validator is offline, the system can safely trigger the `BeforeValidatorSlashed` hook without causing a chain halt. This allows a separate collateral module to be reliably notified and to apply real financial penalties, while the staking module only manages consensus status and abstract power scores.
+
+### 4. Enhanced Logging
+
+- **Insufficient Funds**: The `subUnlockedCoins` function in `x/bank/keeper/send.go` has been updated with detailed logging, including a stack trace, to make debugging `ErrInsufficientFunds` errors easier.
+- **Validator Updates**: Extensive logging was added to the `ApplyAndReturnValidatorSetUpdates` function to trace the lifecycle of validators during state changes.
+- **Gas Costs**: The `gasCostPerIteration` in `x/group/keeper/msg_server.go` was set to `0` to remove gas costs for certain operations. 

--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -11,6 +11,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // HandleValidatorSignature handles a validator signature, must be called once per validator per block.
@@ -104,6 +105,82 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 			"threshold", minSignedPerWindow,
 		)
 	}
+
+	minHeight := signInfo.StartHeight + signedBlocksWindow
+	maxMissed := signedBlocksWindow - minSignedPerWindow
+
+	// if we are past the minimum height and the validator has missed too many blocks, punish them
+	if height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+		validator, err := k.sk.ValidatorByConsAddr(ctx, consAddr)
+		if err != nil {
+			return err
+		}
+		if validator != nil && !validator.IsJailed() {
+			// Downtime confirmed: slash and jail the validator
+			// We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+			// and subtract an additional 1 since this is the LastCommit.
+			// Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+			// i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+			// That's fine since this is just used to filter unbonding delegations & redelegations.
+			distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+
+			slashFractionDowntime, err := k.SlashFractionDowntime(ctx)
+			if err != nil {
+				return err
+			}
+
+			// The `SlashWithInfractionReason` call is now safe because the staking keeper's `Slash` function
+			// has been modified to no longer burn tokens from the bonded pool.
+			coinsBurned, err := k.sk.SlashWithInfractionReason(ctx, consAddr, distributionHeight, power, slashFractionDowntime, stakingtypes.Infraction_INFRACTION_DOWNTIME)
+			if err != nil {
+				return err
+			}
+
+			sdkCtx.EventManager().EmitEvent(
+				sdk.NewEvent(
+					types.EventTypeSlash,
+					sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyBurnedCoins, coinsBurned.String()),
+				),
+			)
+			k.sk.Jail(sdkCtx, consAddr)
+
+			downtimeJailDur, err := k.DowntimeJailDuration(ctx)
+			if err != nil {
+				return err
+			}
+			signInfo.JailedUntil = sdkCtx.BlockHeader().Time.Add(downtimeJailDur)
+
+			// We need to reset the counter & bitmap so that the validator won't be
+			// immediately slashed for downtime upon re-bonding.
+			signInfo.MissedBlocksCounter = 0
+			signInfo.IndexOffset = 0
+			err = k.DeleteMissedBlockBitmap(ctx, consAddr)
+			if err != nil {
+				return err
+			}
+
+			logger.Info(
+				"slashing and jailing validator due to liveness fault",
+				"height", height,
+				"validator", consAddr.String(),
+				"min_height", minHeight,
+				"threshold", minSignedPerWindow,
+				"slashed", slashFractionDowntime.String(),
+				"jailed_until", signInfo.JailedUntil,
+			)
+		} else {
+			// validator was (a) not found or (b) already jailed so we do not slash
+			logger.Info(
+				"validator would have been slashed for downtime, but was either not found in store or already jailed",
+				"validator", consAddr.String(),
+			)
+		}
+	}
+
 	// Set the updated signing info
 	return k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
 }

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -179,18 +179,25 @@ func (k Keeper) Slash(ctx context.Context, consAddr sdk.ConsAddress, infractionH
 		return math.NewInt(0), err
 	}
 
-	switch validator.GetStatus() {
-	case types.Bonded:
-		if err := k.burnBondedTokens(ctx, tokensToBurn); err != nil {
-			return math.NewInt(0), err
-		}
-	case types.Unbonding, types.Unbonded:
-		if err := k.burnNotBondedTokens(ctx, tokensToBurn); err != nil {
-			return math.NewInt(0), err
-		}
-	default:
-		panic("invalid validator status")
-	}
+	// The following block is commented out because this modified staking module
+	// no longer manages real tokens. It only manages abstract "compute power"
+	// scores. The burn functions would attempt to burn real tokens from pools
+	// that are now always empty, causing a chain-halting `insufficient funds`
+	// error. The actual financial penalty (slashing real collateral) is handled
+	// by a separate module that listens for the `BeforeValidatorSlashed` hook.
+	//
+	// switch validator.GetStatus() {
+	// case types.Bonded:
+	// 	if err := k.burnBondedTokens(ctx, tokensToBurn); err != nil {
+	// 		return math.NewInt(0), err
+	// 	}
+	// case types.Unbonding, types.Unbonded:
+	// 	if err := k.burnNotBondedTokens(ctx, tokensToBurn); err != nil {
+	// 		return math.NewInt(0), err
+	// 	}
+	// default:
+	// 	panic("invalid validator status")
+	// }
 
 	logger.Info(
 		"validator slashed by slash factor",


### PR DESCRIPTION
This commit restores the downtime detection mechanism that was previously removed. The fix is implemented in two parts to ensure it operates safely within the new token-less staking model.

1.  **`x/staking/keeper/slash.go`**: The core `Slash` function has been modified to no longer attempt to burn tokens from the bonded pool. A comment has been added to clarify that its role is now to reduce a validator's abstract "compute power" and to trigger hooks. This prevents `insufficient funds` errors.

2.  **`x/slashing/keeper/infractions.go`**: The original downtime detection and penalty logic has been restored. This code now safely calls the modified staking `Slash` function.

This change ensures that the `BeforeValidatorSlashed` hook is reliably triggered for liveness faults, allowing an external collateral module to handle the actual financial penalty.
