### PR TITLE
fix(store/snapshots): prevent chunk deletion during active state sync transfers

### DIFF
--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -237,7 +237,14 @@ func (m *Manager) List() ([]*types.Snapshot, error) {
 
 // LoadChunk loads a chunk into a byte slice, mirroring ABCI LoadChunk. It can be called
 // concurrently with other operations. If the chunk does not exist, nil is returned.
+//
+// The active reader count for the snapshot height is held for the duration of the
+// read so that concurrent Prune/Delete operations wait until the chunk data has been
+// fully consumed before removing files from disk.
 func (m *Manager) LoadChunk(height uint64, format, chunk uint32) ([]byte, error) {
+	m.store.AcquireReader(height)
+	defer m.store.ReleaseReader(height)
+
 	reader, err := m.store.LoadChunk(height, format, chunk)
 	if err != nil {
 		return nil, err

--- a/store/snapshots/store.go
+++ b/store/snapshots/store.go
@@ -31,6 +31,11 @@ type Store struct {
 
 	mtx    sync.Mutex
 	saving map[uint64]bool // heights currently being saved
+
+	// readersMtx protects activeReaders; readersCond is broadcast when a count drops to zero.
+	readersMtx    sync.Mutex
+	readersCond   *sync.Cond
+	activeReaders map[uint64]int // per-height count of in-flight LoadChunk readers
 }
 
 // NewStore creates a new snapshot store.
@@ -43,14 +48,39 @@ func NewStore(db db.DB, dir string) (*Store, error) {
 		return nil, errors.Wrapf(err, "failed to create snapshot directory %q", dir)
 	}
 
-	return &Store{
-		db:     db,
-		dir:    dir,
-		saving: make(map[uint64]bool),
-	}, nil
+	store := &Store{
+		db:            db,
+		dir:           dir,
+		saving:        make(map[uint64]bool),
+		activeReaders: make(map[uint64]int),
+	}
+	store.readersCond = sync.NewCond(&store.readersMtx)
+	return store, nil
 }
 
-// Delete deletes a snapshot.
+// AcquireReader increments the active reader count for the given snapshot height.
+// It must be paired with a corresponding ReleaseReader call.
+func (s *Store) AcquireReader(height uint64) {
+	s.readersMtx.Lock()
+	s.activeReaders[height]++
+	s.readersMtx.Unlock()
+}
+
+// ReleaseReader decrements the active reader count for the given snapshot height
+// and wakes any goroutine waiting in Delete.
+func (s *Store) ReleaseReader(height uint64) {
+	s.readersMtx.Lock()
+	s.activeReaders[height]--
+	if s.activeReaders[height] <= 0 {
+		delete(s.activeReaders, height)
+		s.readersCond.Broadcast()
+	}
+	s.readersMtx.Unlock()
+}
+
+// Delete deletes a snapshot. It waits for any active chunk readers to finish
+// before removing files from disk, preventing the race condition where a peer
+// downloading chunks via state sync gets file-not-found errors mid-transfer.
 func (s *Store) Delete(height uint64, format uint32) error {
 	s.mtx.Lock()
 	saving := s.saving[height]
@@ -59,6 +89,14 @@ func (s *Store) Delete(height uint64, format uint32) error {
 		return errors.Wrapf(storetypes.ErrConflict,
 			"snapshot for height %v format %v is currently being saved", height, format)
 	}
+
+	// Wait for active chunk readers to finish before deleting files.
+	s.readersMtx.Lock()
+	for s.activeReaders[height] > 0 {
+		s.readersCond.Wait()
+	}
+	s.readersMtx.Unlock()
+
 	err := s.db.DeleteSync(encodeKey(height, format))
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete snapshot for height %v format %v",


### PR DESCRIPTION
## Summary

- Add read-side reference counting to the snapshot `Store` so that `Delete` waits for active `LoadChunk` readers to finish before removing files from disk
- This fixes a race condition where `Prune` (called after creating a new snapshot) deletes chunk files while a peer is still downloading them via state sync

## Problem

When a peer is downloading snapshot chunks via state sync:
1. Snapshot at height H is complete, peer starts downloading chunks (0, 1, ... 827)
2. New snapshot at height H+1000 finishes creating in a background goroutine
3. `Prune(keepRecent)` runs immediately after, calling `Delete` → `os.RemoveAll` on snapshot H
4. Peer requests remaining chunks of H → files are gone → `LoadChunk` returns nil
5. CometBFT sends `Missing: true`, peer times out after 2 minutes
6. Issue resolves after ~1 hour when a new snapshot becomes available

`LoadChunk` runs lock-free and concurrent with `Delete`/`Prune`. There was no mechanism to protect files from deletion while they are being served.

## Changes

**`store/snapshots/store.go`**:
- Added `activeReaders map[uint64]int` with `sync.Cond` to `Store` struct
- Added `AcquireReader(height)` / `ReleaseReader(height)` methods
- `Delete` now waits for `activeReaders[height]` to reach zero before calling `os.RemoveAll`

**`store/snapshots/manager.go`**:
- `LoadChunk` now calls `AcquireReader`/`ReleaseReader` around the full read lifecycle

## Test plan

- [ ] Existing snapshot tests pass (`go test ./store/snapshots/...`)
- [ ] Manual test: start state sync on a new node while snapshot pruning is active
- [ ] Verify chunks are no longer deleted mid-transfer

Fixes gonka-ai/gonka#632