### PR TITLE
feat(slashing): add MaintenanceChecker interface for liveness exemption

### DIFF
--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -33,6 +33,19 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 		return nil
 	}
 
+	// Skip missed-block accounting for validators in active maintenance.
+	// During maintenance, liveness accounting is frozen: missed signatures
+	// do not advance counters or bitmaps, and downtime jailing/slashing
+	// is not triggered. Double-sign and evidence paths are unaffected.
+	if k.maintenanceChecker != nil && k.maintenanceChecker.IsValidatorInActiveMaintenance(ctx, consAddr) {
+		logger.Debug(
+			"skipping liveness accounting for maintenance-covered validator",
+			"height", height,
+			"validator", consAddr.String(),
+		)
+		return nil
+	}
+
 	// fetch signing info
 	signInfo, err := k.GetValidatorSigningInfo(ctx, consAddr)
 	if err != nil {

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -15,6 +15,16 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
+// MaintenanceChecker is an optional interface that, when set, allows the
+// slashing keeper to skip missed-block accounting and downtime jailing for
+// validators that are currently in a scheduled maintenance window.
+// This is injected after construction via SetMaintenanceChecker to avoid
+// import cycles between the slashing module and the application-level
+// maintenance state owner.
+type MaintenanceChecker interface {
+	IsValidatorInActiveMaintenance(ctx context.Context, consAddr sdk.ConsAddress) bool
+}
+
 // Keeper of the slashing store
 type Keeper struct {
 	storeService storetypes.KVStoreService
@@ -25,6 +35,10 @@ type Keeper struct {
 	// the address capable of executing a MsgUpdateParams message. Typically, this
 	// should be the x/gov module account.
 	authority string
+
+	// maintenanceChecker is an optional checker for maintenance window exemptions.
+	// When non-nil, validators in active maintenance skip liveness accounting.
+	maintenanceChecker MaintenanceChecker
 }
 
 // NewKeeper creates a slashing keeper
@@ -36,6 +50,12 @@ func NewKeeper(cdc codec.BinaryCodec, legacyAmino *codec.LegacyAmino, storeServi
 		sk:           sk,
 		authority:    authority,
 	}
+}
+
+// SetMaintenanceChecker sets the optional maintenance checker used to exempt
+// validators in active maintenance from downtime liveness accounting.
+func (k *Keeper) SetMaintenanceChecker(mc MaintenanceChecker) {
+	k.maintenanceChecker = mc
 }
 
 // GetAuthority returns the x/slashing module's authority.


### PR DESCRIPTION
## Summary

Add a `MaintenanceChecker` interface to the slashing module so that the inference chain can exempt participants in active maintenance windows from liveness enforcement.

### Problem

When a participant enters a scheduled maintenance window, their node intentionally goes offline. The default slashing module treats this as downtime — it counts missed signatures, jails the validator, and slashes their stake. There is no hook or extension point to prevent this from outside the SDK.

### Changes

- **`x/slashing/keeper/keeper.go`**: Add `MaintenanceChecker` interface and `SetMaintenanceChecker` injection method
- **`x/slashing/keeper/infractions.go`**: Check `MaintenanceChecker` in the liveness handling path — if a validator is in active maintenance, freeze missed-signature accounting and skip downtime jailing/slashing
- Double-sign and evidence handling paths are **unchanged**

### How it works

1. The inference chain implements `MaintenanceChecker` via a `MaintenanceSlashingAdapter` that bridges consensus addresses to participant maintenance state
2. During app initialization, the adapter is injected into the slashing keeper via `SetMaintenanceChecker()`
3. At each begin-block liveness check, if the checker reports the validator is in active maintenance, missed blocks are not counted and no jail/slash occurs
4. Once maintenance ends, normal liveness enforcement resumes automatically

### Design decisions

- **Interface injection** (not import): The slashing module depends on an interface, not on the inference module directly — keeps the SDK fork minimal and reusable
- **Opt-in**: If `SetMaintenanceChecker` is never called, behavior is identical to upstream Cosmos SDK
- **Scope limited to liveness**: Only downtime handling is affected; double-sign/evidence paths remain untouched
