### PR TITLE
fix(staking): resolve stale validator consensus key conflicts (GON-191)

### DIFF
--- a/x/staking/keeper/compute.go
+++ b/x/staking/keeper/compute.go
@@ -130,7 +130,18 @@ func (k Keeper) SetComputeValidators(
 		currentValsByConsensusAddress[consensusAddress] = val
 	}
 
-	computeResults = sortAndFilterComputeResult(ctx, computeResults, currentValsByConsensusAddress, currentValsByOperatorAddress)
+	computeResults, staleToRemove := sortAndFilterComputeResult(ctx, computeResults, currentValsByConsensusAddress, currentValsByOperatorAddress)
+
+	// Remove stale (tokens=0) validators that were blocking new participants from claiming
+	// their consensus key or changing it. The filter has already removed these from
+	// currentValsByConsensusAddress / currentValsByOperatorAddress so the downstream
+	// not-in-compute-results loop and create/update loop will treat the new entry as a
+	// fresh validator. See GON-191.
+	for _, stale := range staleToRemove {
+		if err := k.markValidatorForDeletion(ctx, stale); err != nil {
+			logger.Error("failed to mark stale validator for deletion", "operator", stale.OperatorAddress, "error", err)
+		}
+	}
 
 	resultsByOperatorAddress := make(map[string]ComputeResult)
 	for _, res := range computeResults {
@@ -194,7 +205,7 @@ func sortAndFilterComputeResult(
 	computeResults []ComputeResult,
 	currentValsByConsensusAddress map[string]types.Validator,
 	currentValsByOperatorAddress map[string]types.Validator,
-) []ComputeResult {
+) ([]ComputeResult, []types.Validator) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	logger := sdkCtx.Logger()
 
@@ -232,7 +243,7 @@ func sortAndFilterComputeResult(
 	)
 
 	beforeFilter := computeResults
-	computeResults = filterBasedOnExisting(ctx, computeResults, currentValsByConsensusAddress, currentValsByOperatorAddress)
+	computeResults, staleToRemove := filterBasedOnExisting(ctx, computeResults, currentValsByConsensusAddress, currentValsByOperatorAddress)
 	logComputeResultsFilterStats(logger, "filter_based_on_existing", beforeFilter, computeResults)
 
 	beforeFilter = computeResults
@@ -243,7 +254,7 @@ func sortAndFilterComputeResult(
 	computeResults = filterDuplicateConsensusKeys(ctx, computeResults)
 	logComputeResultsFilterStats(logger, "filter_duplicate_consensus_keys", beforeFilter, computeResults)
 
-	return computeResults
+	return computeResults, staleToRemove
 }
 
 func sortComputeResultsInplace(computeResults []ComputeResult) {
@@ -279,15 +290,30 @@ func filterInvalidComputeResults(ctx context.Context, computeResults []ComputeRe
 	return filtered
 }
 
+// filterBasedOnExisting filters compute results against the existing validator set,
+// resolving conflicts where possible. It returns the filtered results and a list of
+// stale (tokens=0) validators that the caller should mark for deletion.
+//
+// Stale-conflict resolution (GON-191): when a participant re-registers with a fresh
+// account but reuses the same ed25519 validator key, the old validator entry can
+// remain in the staking store with tokens=0 and permanently block the new account
+// from claiming that consensus key. Previously the filter silently rejected the new
+// compute result; it now removes the stale entry from the working maps and signals
+// to the caller (via the returned slice) that it should be deleted from the store.
+//
+// The same logic applies when an operator changes its consensus key: if the old
+// entry has zero tokens, allow the change instead of rejecting it.
 func filterBasedOnExisting(
 	ctx context.Context,
 	computeResults []ComputeResult,
 	currentValsByConsensusAddress map[string]types.Validator,
 	currentValsByOperatorAddress map[string]types.Validator,
-) []ComputeResult {
+) ([]ComputeResult, []types.Validator) {
 	logger := sdk.UnwrapSDKContext(ctx).Logger()
 
 	filtered := make([]ComputeResult, 0, len(computeResults))
+	var staleToRemove []types.Validator
+
 	for _, res := range computeResults {
 		if res.ValidatorPubKey == nil || res.Power <= 0 {
 			continue
@@ -296,21 +322,49 @@ func filterBasedOnExisting(
 		consensusAddress := res.ValidatorPubKey.Address().String()
 		if val, exists := currentValsByConsensusAddress[consensusAddress]; exists {
 			if val.OperatorAddress != res.OperatorAddress {
-				logger.Warn("validator with the same consensus pubkey already exists, rejecting a new one", "consensusAddress", consensusAddress, "existingValidator", val.OperatorAddress, "newValidator", res.OperatorAddress)
-				continue
+				if val.Tokens.IsZero() {
+					logger.Info("removing stale zero-power validator to resolve consensus key conflict",
+						"consensusAddress", consensusAddress,
+						"staleOperator", val.OperatorAddress,
+						"newOperator", res.OperatorAddress)
+					staleToRemove = append(staleToRemove, val)
+					delete(currentValsByConsensusAddress, consensusAddress)
+					delete(currentValsByOperatorAddress, val.OperatorAddress)
+				} else {
+					logger.Warn("validator with the same consensus pubkey already exists, rejecting a new one", "consensusAddress", consensusAddress, "existingValidator", val.OperatorAddress, "newValidator", res.OperatorAddress)
+					continue
+				}
 			}
 		}
 
 		val, exists := currentValsByOperatorAddress[res.OperatorAddress]
-		if exists && val.ConsensusPubkey.GetCachedValue().(cryptotypes.PubKey).Address().String() != res.ValidatorPubKey.Address().String() {
-			logger.Warn("validator changed consensus pubkey, removing from validator set", "operator", val.OperatorAddress, "existingConsensusKey", val.ConsensusPubkey.GetCachedValue().(cryptotypes.PubKey).Address().String(), "newConsensusKey", res.ValidatorPubKey.Address().String())
-			continue
+		if exists {
+			existingConsKey := val.ConsensusPubkey.GetCachedValue().(cryptotypes.PubKey).Address().String()
+			if existingConsKey != res.ValidatorPubKey.Address().String() {
+				if val.Tokens.IsZero() {
+					logger.Info("allowing consensus key change for zero-power validator",
+						"operator", val.OperatorAddress,
+						"oldConsensusKey", existingConsKey,
+						"newConsensusKey", res.ValidatorPubKey.Address().String())
+					staleToRemove = append(staleToRemove, val)
+					delete(currentValsByOperatorAddress, res.OperatorAddress)
+					// Also drop the stale entry from the consensus-key map. Without this,
+					// a later compute result in the same batch that happens to reuse the
+					// old consensus key would find this ghost entry, see tokens=0, and
+					// queue the same stale validator for deletion a second time — causing
+					// a duplicate markValidatorForDeletion call. (PR review, GLiberman.)
+					delete(currentValsByConsensusAddress, existingConsKey)
+				} else {
+					logger.Warn("validator changed consensus pubkey, removing from validator set", "operator", val.OperatorAddress, "existingConsensusKey", existingConsKey, "newConsensusKey", res.ValidatorPubKey.Address().String())
+					continue
+				}
+			}
 		}
 
 		filtered = append(filtered, res)
 	}
 
-	return filtered
+	return filtered, staleToRemove
 }
 
 func filterDuplicateOperatorAddresses(ctx context.Context, computeResults []ComputeResult) []ComputeResult {

--- a/x/staking/keeper/compute_test.go
+++ b/x/staking/keeper/compute_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
@@ -86,10 +87,10 @@ func TestSortAndFilterComputeResult_FromJSON(t *testing.T) {
 
 	// Run twice to ensure deterministic output (function sorts/filters internally).
 	in1 := append([]ComputeResult(nil), computeResults...)
-	out1 := sortAndFilterComputeResult(ctx, in1, emptyByCons, emptyByOp)
+	out1, _ := sortAndFilterComputeResult(ctx, in1, emptyByCons, emptyByOp)
 
 	in2 := append([]ComputeResult(nil), computeResults...)
-	out2 := sortAndFilterComputeResult(ctx, in2, emptyByCons, emptyByOp)
+	out2, _ := sortAndFilterComputeResult(ctx, in2, emptyByCons, emptyByOp)
 
 	if len(out1) != len(out2) {
 		t.Fatalf("non-deterministic output length: first=%d second=%d", len(out1), len(out2))
@@ -181,6 +182,9 @@ func TestSortAndFilterComputeResult_FiltersAgainstExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create existing validator: %v", err)
 	}
+	// Give the existing validator non-zero tokens so the conflict-rejection assertions
+	// in this test still apply (GON-191 only relaxes rejection when tokens are zero).
+	existing.Tokens = math.NewInt(10)
 
 	currentByCons := map[string]types.Validator{
 		pk1.Address().String(): existing,
@@ -209,7 +213,7 @@ func TestSortAndFilterComputeResult_FiltersAgainstExisting(t *testing.T) {
 		{OperatorAddress: "op8", ValidatorPubKey: pk3, Power: -1}, // invalid (non-positive power)
 	}
 
-	out := sortAndFilterComputeResult(ctx, input, currentByCons, currentByOp)
+	out, _ := sortAndFilterComputeResult(ctx, input, currentByCons, currentByOp)
 
 	// Expect: op1 survives with pk1; op3 survives with the lexicographically smallest pubkey addr among (pk2, pk3);
 	// and only one of (op5, op6) survives for pk4 (the earlier operator in sort order).
@@ -250,5 +254,244 @@ func TestSortAndFilterComputeResult_FiltersAgainstExisting(t *testing.T) {
 				t.Fatalf("op1 did not keep existing consensus key: got=%s want=%s", res.ValidatorPubKey.Address().String(), pk1.Address().String())
 			}
 		}
+	}
+}
+
+// TestFilterBasedOnExisting_StaleConsensusKeyConflict covers GON-191 Change 1:
+// when a new operator claims a consensus key that is still held by a stale
+// (tokens=0) validator owned by a different operator, the filter should allow
+// the new entry and report the stale validator for deletion.
+func TestFilterBasedOnExisting_StaleConsensusKeyConflict(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey("compute_test_stale_cons")
+	tkey := storetypes.NewTransientStoreKey("transient_compute_test_stale_cons")
+	sdkCtx := testutil.DefaultContext(key, tkey)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	sharedKey := mustEd25519PubKey(t, 0x10)
+
+	// Stale validator: registered to opStale, but with tokens=0 (e.g., decommissioned).
+	stale, err := types.NewValidator("opStale", sharedKey, types.Description{Moniker: "opStale"})
+	if err != nil {
+		t.Fatalf("failed to create stale validator: %v", err)
+	}
+	// Tokens already zero by default; assert that explicitly so the intent is clear.
+	if !stale.Tokens.IsZero() {
+		t.Fatalf("expected stale validator to have zero tokens by default, got %s", stale.Tokens)
+	}
+
+	currentByCons := map[string]types.Validator{
+		sharedKey.Address().String(): stale,
+	}
+	currentByOp := map[string]types.Validator{
+		"opStale": stale,
+	}
+
+	input := []ComputeResult{
+		{OperatorAddress: "opNew", ValidatorPubKey: sharedKey, Power: 10},
+	}
+
+	out, staleToRemove := filterBasedOnExisting(ctx, input, currentByCons, currentByOp)
+
+	if len(out) != 1 || out[0].OperatorAddress != "opNew" {
+		t.Fatalf("expected new operator to pass through filter, got %+v", out)
+	}
+	if len(staleToRemove) != 1 || staleToRemove[0].OperatorAddress != "opStale" {
+		t.Fatalf("expected stale validator opStale to be returned for deletion, got %+v", staleToRemove)
+	}
+	// The filter must have removed the stale entries from the working maps so the
+	// downstream create path treats opNew as a fresh validator.
+	if _, exists := currentByCons[sharedKey.Address().String()]; exists {
+		t.Fatalf("stale entry still present in currentByCons after filter")
+	}
+	if _, exists := currentByOp["opStale"]; exists {
+		t.Fatalf("stale entry still present in currentByOp after filter")
+	}
+}
+
+// TestFilterBasedOnExisting_NonStaleConsensusKeyConflict ensures the rejection path
+// is preserved for active validators: an active (tokens>0) validator's consensus key
+// cannot be hijacked by a different operator.
+func TestFilterBasedOnExisting_NonStaleConsensusKeyConflict(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey("compute_test_active_cons")
+	tkey := storetypes.NewTransientStoreKey("transient_compute_test_active_cons")
+	sdkCtx := testutil.DefaultContext(key, tkey)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	sharedKey := mustEd25519PubKey(t, 0x11)
+
+	active, err := types.NewValidator("opActive", sharedKey, types.Description{Moniker: "opActive"})
+	if err != nil {
+		t.Fatalf("failed to create active validator: %v", err)
+	}
+	active.Tokens = math.NewInt(100)
+
+	currentByCons := map[string]types.Validator{
+		sharedKey.Address().String(): active,
+	}
+	currentByOp := map[string]types.Validator{
+		"opActive": active,
+	}
+
+	input := []ComputeResult{
+		{OperatorAddress: "opAttacker", ValidatorPubKey: sharedKey, Power: 10},
+	}
+
+	out, staleToRemove := filterBasedOnExisting(ctx, input, currentByCons, currentByOp)
+
+	if len(out) != 0 {
+		t.Fatalf("expected attacker entry to be rejected when active validator owns the key, got %+v", out)
+	}
+	if len(staleToRemove) != 0 {
+		t.Fatalf("expected no stale removals for active conflict, got %+v", staleToRemove)
+	}
+	if _, exists := currentByCons[sharedKey.Address().String()]; !exists {
+		t.Fatalf("active entry must remain in currentByCons after rejection")
+	}
+}
+
+// TestFilterBasedOnExisting_StaleOperatorKeyChange covers GON-191 Change 2:
+// when the same operator submits a compute result with a different consensus key
+// and the existing entry has tokens=0, the filter should allow the key change and
+// report the stale entry for deletion.
+func TestFilterBasedOnExisting_StaleOperatorKeyChange(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey("compute_test_stale_op_change")
+	tkey := storetypes.NewTransientStoreKey("transient_compute_test_stale_op_change")
+	sdkCtx := testutil.DefaultContext(key, tkey)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	oldKey := mustEd25519PubKey(t, 0x20)
+	newKey := mustEd25519PubKey(t, 0x21)
+
+	stale, err := types.NewValidator("opSame", oldKey, types.Description{Moniker: "opSame"})
+	if err != nil {
+		t.Fatalf("failed to create stale validator: %v", err)
+	}
+	if !stale.Tokens.IsZero() {
+		t.Fatalf("expected stale validator to have zero tokens by default, got %s", stale.Tokens)
+	}
+
+	currentByCons := map[string]types.Validator{
+		oldKey.Address().String(): stale,
+	}
+	currentByOp := map[string]types.Validator{
+		"opSame": stale,
+	}
+
+	input := []ComputeResult{
+		{OperatorAddress: "opSame", ValidatorPubKey: newKey, Power: 10},
+	}
+
+	out, staleToRemove := filterBasedOnExisting(ctx, input, currentByCons, currentByOp)
+
+	if len(out) != 1 || out[0].OperatorAddress != "opSame" || out[0].ValidatorPubKey.Address().String() != newKey.Address().String() {
+		t.Fatalf("expected key change to pass through filter, got %+v", out)
+	}
+	if len(staleToRemove) != 1 || staleToRemove[0].OperatorAddress != "opSame" {
+		t.Fatalf("expected stale opSame to be returned for deletion, got %+v", staleToRemove)
+	}
+	if _, exists := currentByOp["opSame"]; exists {
+		t.Fatalf("stale entry still present in currentByOp after filter")
+	}
+}
+
+// TestFilterBasedOnExisting_NonStaleOperatorKeyChange ensures an active operator
+// cannot silently swap its consensus key — that path must still be rejected to
+// preserve the existing safety property that consensus-key changes for live
+// validators are not allowed.
+func TestFilterBasedOnExisting_NonStaleOperatorKeyChange(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey("compute_test_active_op_change")
+	tkey := storetypes.NewTransientStoreKey("transient_compute_test_active_op_change")
+	sdkCtx := testutil.DefaultContext(key, tkey)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	oldKey := mustEd25519PubKey(t, 0x30)
+	newKey := mustEd25519PubKey(t, 0x31)
+
+	active, err := types.NewValidator("opSame", oldKey, types.Description{Moniker: "opSame"})
+	if err != nil {
+		t.Fatalf("failed to create active validator: %v", err)
+	}
+	active.Tokens = math.NewInt(100)
+
+	currentByCons := map[string]types.Validator{
+		oldKey.Address().String(): active,
+	}
+	currentByOp := map[string]types.Validator{
+		"opSame": active,
+	}
+
+	input := []ComputeResult{
+		{OperatorAddress: "opSame", ValidatorPubKey: newKey, Power: 10},
+	}
+
+	out, staleToRemove := filterBasedOnExisting(ctx, input, currentByCons, currentByOp)
+
+	if len(out) != 0 {
+		t.Fatalf("expected key change for active validator to be rejected, got %+v", out)
+	}
+	if len(staleToRemove) != 0 {
+		t.Fatalf("expected no stale removals for active key-change rejection, got %+v", staleToRemove)
+	}
+}
+
+// TestFilterBasedOnExisting_StaleKeyChangeNoGhostDoubleRemoval is the regression
+// test for GLiberman's review on PR #14: when Change 2 (operator changes consensus
+// key) allows a zero-power validator through, the stale entry must be dropped
+// from BOTH the operator map and the consensus-key map. If only the operator map
+// is pruned, a later compute result in the same batch that happens to reference
+// the old consensus key would find the ghost entry, see tokens=0, and queue the
+// same stale validator for deletion a second time.
+func TestFilterBasedOnExisting_StaleKeyChangeNoGhostDoubleRemoval(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey("compute_test_ghost_double_removal")
+	tkey := storetypes.NewTransientStoreKey("transient_compute_test_ghost_double_removal")
+	sdkCtx := testutil.DefaultContext(key, tkey)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	oldKey := mustEd25519PubKey(t, 0x40)
+	newKey := mustEd25519PubKey(t, 0x41)
+
+	// Stale validator opSame currently registered with oldKey, tokens=0.
+	stale, err := types.NewValidator("opSame", oldKey, types.Description{Moniker: "opSame"})
+	if err != nil {
+		t.Fatalf("failed to create stale validator: %v", err)
+	}
+
+	currentByCons := map[string]types.Validator{
+		oldKey.Address().String(): stale,
+	}
+	currentByOp := map[string]types.Validator{
+		"opSame": stale,
+	}
+
+	// Two compute results in the same batch:
+	//   1. opSame switching from oldKey to newKey (Change 2 path, stale allowed)
+	//   2. opOther claiming oldKey for itself (Change 1 path, would find ghost)
+	// Without the consensus-key-map cleanup, the second entry would re-discover
+	// the stale validator and append it to staleToRemove a second time.
+	input := []ComputeResult{
+		{OperatorAddress: "opSame", ValidatorPubKey: newKey, Power: 10},
+		{OperatorAddress: "opOther", ValidatorPubKey: oldKey, Power: 10},
+	}
+
+	out, staleToRemove := filterBasedOnExisting(ctx, input, currentByCons, currentByOp)
+
+	if len(out) != 2 {
+		t.Fatalf("expected both compute results to pass through filter, got %+v", out)
+	}
+	if len(staleToRemove) != 1 {
+		t.Fatalf("expected stale validator to be queued for removal exactly once, got %d entries: %+v", len(staleToRemove), staleToRemove)
+	}
+	if staleToRemove[0].OperatorAddress != "opSame" {
+		t.Fatalf("expected stale opSame in removal list, got %+v", staleToRemove[0])
 	}
 }

--- a/x/staking/keeper/export_test.go
+++ b/x/staking/keeper/export_test.go
@@ -1,0 +1,15 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// DeleteValidatorInternalForTest exposes the unexported deleteValidatorInternal
+// method for use by black-box tests in package keeper_test. It is only compiled
+// during tests (file ends in _test.go) and does not appear in the public API.
+func (k Keeper) DeleteValidatorInternalForTest(ctx context.Context, validator types.Validator, valAddr sdk.ValAddress) error {
+	return k.deleteValidatorInternal(ctx, validator, valAddr)
+}

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -88,9 +88,19 @@ func (k Keeper) deleteValidatorInternal(ctx context.Context, validator types.Val
 		return err
 	}
 
-	// Delete consensus address mapping
-	if err := store.Delete(types.GetValidatorByConsAddrKey(consAddr)); err != nil {
+	// Delete consensus address mapping, but only if it still points to this validator.
+	// In stale-validator-replacement (GON-191), a new validator may have taken over the
+	// same consensus key in the same block via SetValidatorByConsAddr. Unconditionally
+	// deleting here would orphan the new validator's cons-addr index entry.
+	consAddrKey := types.GetValidatorByConsAddrKey(consAddr)
+	existingOp, err := store.Get(consAddrKey)
+	if err != nil {
 		return err
+	}
+	if existingOp != nil && bytes.Equal(existingOp, valAddr) {
+		if err := store.Delete(consAddrKey); err != nil {
+			return err
+		}
 	}
 
 	// Delete power index

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -37,6 +37,12 @@ func (k Keeper) BlockValidatorUpdates(ctx context.Context) ([]abci.ValidatorUpda
 // DeleteZeroPowerValidators deletes validators with zero power that are not in LastValidatorPower.
 // Only deletes validators already processed by ApplyAndReturnValidatorSetUpdates (not in LastValidatorPower),
 // preventing errors from deleting validators that ApplyAndReturnValidatorSetUpdates still needs to fetch.
+//
+// For UNBONDING validators with zero tokens, the unbonding queue entry and per-id unbonding indexes
+// are also removed so that a later UnbondAllMatureValidators run does not error when it tries to
+// fetch the now-deleted validator. This is safe for compute-power validators because there are no
+// staked tokens to wait for the unbonding period — the queue entry would otherwise just expire
+// 21 days later against a non-existent validator.
 func (k Keeper) DeleteZeroPowerValidators(ctx context.Context) error {
 	logger := k.Logger(ctx)
 
@@ -46,28 +52,62 @@ func (k Keeper) DeleteZeroPowerValidators(ctx context.Context) error {
 	}
 
 	for _, validator := range allValidators {
-		if validator.GetTokens().IsZero() {
-			valAddr, err := k.validatorAddressCodec.StringToBytes(validator.GetOperator())
-			if err != nil {
-				logger.Error("failed to convert operator address", "operator", validator.GetOperator(), "error", err)
-				continue
-			}
+		if err := k.tryDeleteZeroPowerValidator(ctx, validator); err != nil {
+			logger.Error("failed to delete zero-power validator", "operator", validator.GetOperator(), "error", err)
+		}
+	}
 
-			// Only delete if already removed from LastValidatorPower (ApplyAndReturnValidatorSetUpdates processed it)
-			_, err = k.GetLastValidatorPower(ctx, valAddr)
-			if err == nil {
-				logger.Debug("skipping zero-power validator still in LastValidatorPower",
-					"operator", validator.GetOperator())
-				continue
-			}
+	return nil
+}
 
-			logger.Info("deleting zero-power validator", "operator", validator.GetOperator())
+// tryDeleteZeroPowerValidator deletes a single zero-power validator if it is eligible.
+// Returns nil for both "deleted" and "skipped (still in LastValidatorPower / non-zero tokens)";
+// only returns an error if a store operation failed.
+func (k Keeper) tryDeleteZeroPowerValidator(ctx context.Context, validator types.Validator) error {
+	if !validator.GetTokens().IsZero() {
+		return nil
+	}
 
-			if err := k.deleteValidatorInternal(ctx, validator, valAddr); err != nil {
-				logger.Error("failed to delete validator", "operator", validator.GetOperator(), "error", err)
-				continue
+	logger := k.Logger(ctx)
+	store := k.storeService.OpenKVStore(ctx)
+
+	valAddr, err := k.validatorAddressCodec.StringToBytes(validator.GetOperator())
+	if err != nil {
+		return fmt.Errorf("failed to convert operator address: %w", err)
+	}
+
+	// Only delete if already removed from LastValidatorPower (ApplyAndReturnValidatorSetUpdates processed it).
+	// We check the store key directly because GetLastValidatorPower returns (0, nil) for both
+	// "key absent" and "value is the encoded int 0", so the err value alone can't disambiguate.
+	hasLastPower, err := store.Has(types.GetLastValidatorPowerKey(valAddr))
+	if err != nil {
+		return fmt.Errorf("failed to read LastValidatorPower: %w", err)
+	}
+	if hasLastPower {
+		logger.Debug("skipping zero-power validator still in LastValidatorPower",
+			"operator", validator.GetOperator())
+		return nil
+	}
+
+	// UNBONDING validators have an entry in the validator unbonding queue (time-slice + per-id index).
+	// UnbondAllMatureValidators will later iterate that queue and call GetValidator on this address;
+	// if we delete the validator without dequeuing, that call returns ErrNoValidatorFound and the
+	// staking EndBlocker returns an error (chain halt). Dequeue first, then delete.
+	if validator.IsUnbonding() {
+		for _, id := range validator.UnbondingIds {
+			if err := k.DeleteUnbondingIndex(ctx, id); err != nil {
+				return fmt.Errorf("failed to delete unbonding index id=%d: %w", id, err)
 			}
 		}
+		if err := k.DeleteValidatorQueue(ctx, validator); err != nil {
+			return fmt.Errorf("failed to dequeue validator from unbonding queue: %w", err)
+		}
+	}
+
+	logger.Info("deleting zero-power validator", "operator", validator.GetOperator())
+
+	if err := k.deleteValidatorInternal(ctx, validator, valAddr); err != nil {
+		return fmt.Errorf("failed to delete validator: %w", err)
 	}
 
 	return nil

--- a/x/staking/keeper/val_state_change_test.go
+++ b/x/staking/keeper/val_state_change_test.go
@@ -1,0 +1,95 @@
+package keeper_test
+
+import (
+	"cosmossdk.io/math"
+
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// TestDeleteValidatorInternal_PreservesReassignedConsAddrIndex exercises the
+// GON-191 defensive check: when a stale (tokens=0) validator's main entry is
+// being cleaned up but the cons-addr index has already been reassigned in the
+// same block to a new validator (via filterBasedOnExisting's stale-conflict
+// resolution path), the cleanup must NOT delete the cons-addr index entry that
+// the new validator now owns.
+//
+// Without the defensive check, the new validator would be orphaned from any
+// lookup-by-consensus-address (slashing, evidence handling, jailing), which is
+// the root cause of the symptom GON-191 set out to fix.
+func (s *KeeperTestSuite) TestDeleteValidatorInternal_PreservesReassignedConsAddrIndex() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	pks := simtestutil.CreateTestPubKeys(3)
+	sharedConsPK := pks[0]
+	opA := sdk.ValAddress(pks[1].Address())
+	opB := sdk.ValAddress(pks[2].Address())
+
+	// Stale validator A with the shared consensus key, tokens=0.
+	valA, err := stakingtypes.NewValidator(opA.String(), sharedConsPK, stakingtypes.Description{Moniker: "opA"})
+	require.NoError(err)
+	valA.Status = stakingtypes.Unbonded
+	valA.Tokens = math.ZeroInt()
+	require.NoError(keeper.SetValidator(ctx, valA))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, valA))
+
+	// New validator B claims the same consensus key. SetValidatorByConsAddr
+	// overwrites the cons-addr index to point at B's operator address.
+	valB, err := stakingtypes.NewValidator(opB.String(), sharedConsPK, stakingtypes.Description{Moniker: "opB"})
+	require.NoError(err)
+	valB.Status = stakingtypes.Bonded
+	valB.Tokens = math.NewInt(100)
+	require.NoError(keeper.SetValidator(ctx, valB))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, valB))
+
+	consAddr, err := valA.GetConsAddr()
+	require.NoError(err)
+	owner, err := keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err)
+	require.Equal(opB.String(), owner.OperatorAddress, "precondition: cons-addr index must point to B after overwrite")
+
+	// Delete the stale validator. Without the defensive check this would also
+	// erase the cons-addr index that now points at B.
+	require.NoError(keeper.DeleteValidatorInternalForTest(ctx, valA, opA))
+
+	ownerAfter, err := keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err, "cons-addr index must still resolve after stale cleanup")
+	require.Equal(opB.String(), ownerAfter.OperatorAddress, "cons-addr index must still point to B; deleting stale A must not orphan B")
+
+	// Stale A's main store entry is gone.
+	_, err = keeper.GetValidator(ctx, opA)
+	require.Error(err, "stale validator A's main store entry should be removed")
+}
+
+// TestDeleteValidatorInternal_DeletesUnreassignedConsAddrIndex confirms that the
+// defensive check does not break the normal cleanup path: when no other
+// validator has claimed the cons-addr index, deletion still removes it.
+func (s *KeeperTestSuite) TestDeleteValidatorInternal_DeletesUnreassignedConsAddrIndex() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	pks := simtestutil.CreateTestPubKeys(2)
+	consPK := pks[0]
+	op := sdk.ValAddress(pks[1].Address())
+
+	val, err := stakingtypes.NewValidator(op.String(), consPK, stakingtypes.Description{Moniker: "op"})
+	require.NoError(err)
+	val.Status = stakingtypes.Unbonded
+	val.Tokens = math.ZeroInt()
+	require.NoError(keeper.SetValidator(ctx, val))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, val))
+
+	consAddr, err := val.GetConsAddr()
+	require.NoError(err)
+
+	owner, err := keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err)
+	require.Equal(op.String(), owner.OperatorAddress)
+
+	require.NoError(keeper.DeleteValidatorInternalForTest(ctx, val, op))
+
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.Error(err, "cons-addr index should be deleted when this validator still owned it")
+}

--- a/x/staking/keeper/val_state_change_test.go
+++ b/x/staking/keeper/val_state_change_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	"cosmossdk.io/math"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
@@ -92,4 +94,91 @@ func (s *KeeperTestSuite) TestDeleteValidatorInternal_DeletesUnreassignedConsAdd
 
 	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
 	require.Error(err, "cons-addr index should be deleted when this validator still owned it")
+}
+
+// TestDeleteZeroPowerValidators_RemovesUnbondingStaleEntry exercises the
+// follow-up to GON-191's filter/cons-addr fix: stale (tokens=0, UNBONDING)
+// validators must actually get cleaned up at the next block, instead of
+// accumulating forever. The previous implementation always skipped because
+// its "still in LastValidatorPower" check used GetLastValidatorPower whose
+// (0, nil) "not found" return collided with the success path, causing every
+// validator to be skipped.
+//
+// This test puts a validator into the same state ApplyAndReturnValidatorSetUpdates
+// would leave it after the bondedToUnbonding transition (status=UNBONDING,
+// tokens=0, not in LastValidatorPower, sitting in the unbonding queue) and
+// verifies DeleteZeroPowerValidators removes it and dequeues its unbonding-
+// queue entries — without dequeuing, UnbondAllMatureValidators would error
+// later trying to fetch the deleted validator.
+func (s *KeeperTestSuite) TestDeleteZeroPowerValidators_RemovesUnbondingStaleEntry() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	pks := simtestutil.CreateTestPubKeys(2)
+	consPK := pks[0]
+	op := sdk.ValAddress(pks[1].Address())
+
+	val, err := stakingtypes.NewValidator(op.String(), consPK, stakingtypes.Description{Moniker: "stale"})
+	require.NoError(err)
+	val.Status = stakingtypes.Unbonding
+	val.Tokens = math.ZeroInt()
+	val.UnbondingTime = ctx.BlockHeader().Time.Add(24 * time.Hour)
+	val.UnbondingHeight = ctx.BlockHeader().Height
+	val.UnbondingIds = []uint64{1}
+	require.NoError(keeper.SetValidator(ctx, val))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, val))
+	require.NoError(keeper.InsertUnbondingValidatorQueue(ctx, val))
+
+	// Sanity precondition: validator + queue entry exist; LastValidatorPower is absent.
+	_, err = keeper.GetValidator(ctx, op)
+	require.NoError(err, "precondition: stale validator should exist before cleanup")
+	queued, err := keeper.GetUnbondingValidators(ctx, val.UnbondingTime, val.UnbondingHeight)
+	require.NoError(err)
+	require.Len(queued, 1, "precondition: validator should be in unbonding queue")
+
+	require.NoError(keeper.DeleteZeroPowerValidators(ctx))
+
+	// Validator entry is gone.
+	_, err = keeper.GetValidator(ctx, op)
+	require.Error(err, "stale UNBONDING tokens=0 validator should be deleted by DeleteZeroPowerValidators")
+
+	// Cons-addr index entry is gone (no reassignment, so we expect normal cleanup).
+	consAddr, err := val.GetConsAddr()
+	require.NoError(err)
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.Error(err, "cons-addr index should be removed when validator is deleted")
+
+	// Unbonding-queue entry is gone so UnbondAllMatureValidators won't error later.
+	queuedAfter, err := keeper.GetUnbondingValidators(ctx, val.UnbondingTime, val.UnbondingHeight)
+	require.NoError(err)
+	require.Empty(queuedAfter, "validator's unbonding-queue entry must be removed alongside deletion")
+}
+
+// TestDeleteZeroPowerValidators_SkipsValidatorStillInLastValidatorPower confirms
+// that the multi-block contract is preserved: a validator with tokens=0 whose
+// LastValidatorPower entry has NOT yet been cleared by ApplyAndReturnValidatorSetUpdates
+// must not be deleted, because the deletion would skip the
+// ValidatorUpdate(power=0) notification to CometBFT.
+func (s *KeeperTestSuite) TestDeleteZeroPowerValidators_SkipsValidatorStillInLastValidatorPower() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	pks := simtestutil.CreateTestPubKeys(2)
+	consPK := pks[0]
+	op := sdk.ValAddress(pks[1].Address())
+
+	val, err := stakingtypes.NewValidator(op.String(), consPK, stakingtypes.Description{Moniker: "mid-cleanup"})
+	require.NoError(err)
+	val.Status = stakingtypes.Bonded
+	val.Tokens = math.ZeroInt()
+	require.NoError(keeper.SetValidator(ctx, val))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, val))
+
+	// Still in LastValidatorPower — ApplyAndReturnValidatorSetUpdates hasn't run yet for this block.
+	require.NoError(keeper.SetLastValidatorPower(ctx, op, 0))
+
+	require.NoError(keeper.DeleteZeroPowerValidators(ctx))
+
+	_, err = keeper.GetValidator(ctx, op)
+	require.NoError(err, "validator must NOT be deleted while still present in LastValidatorPower; ApplyAndReturnValidatorSetUpdates needs to fetch it next")
 }


### PR DESCRIPTION
## Summary

Sub-issue of GON-179 (validator voting weight bug).

When a participant re-registers under a new account but reuses the same ed25519 validator key, the old validator entry (with `tokens=0`) remains in the staking store and permanently blocks the new account from claiming that consensus key. `filterBasedOnExisting` in `compute.go` silently rejected the new compute result.

**Probable scenario** (from the Linear ticket):
1. Person runs a node, creates account A with secp256k1 wallet key 1
2. Their validator node has ed25519 key `BSqH9nNh6Jh...` in `priv_validator_key.json`
3. They register as a participant under A — validator gets created as `cosmosvaloper(A)` with that ed25519 key
4. Later they create account B with secp256k1 wallet key 2
5. They re-register under B using the same node (same `priv_validator_key.json`)
6. `x/group` gets updated with B + the same ed25519 pubkey
7. The old validator entry for A still sits in the staking store, holding the consensus key slot

This PR allows the new entry through when the conflicting existing validator has zero tokens, and removes the stale entry. The same relaxation applies when an existing operator changes its consensus key and the old entry has zero tokens.

## Changes

- **`x/staking/keeper/compute.go`**
  - `filterBasedOnExisting` now returns `(filtered, staleToRemove)`. When a tokens=0 conflict is detected (either Change 1: different operator owns the consensus key, or Change 2: same operator with a different consensus key), the stale entry is collected for removal and the new entry is allowed through. The working maps (`currentValsByConsensusAddress`, `currentValsByOperatorAddress`) are pruned so the downstream create-path treats the new entry as fresh.
  - `sortAndFilterComputeResult` propagates `staleToRemove`.
  - `SetComputeValidators` calls `markValidatorForDeletion` for each stale validator before the create/update loop.

- **`x/staking/keeper/val_state_change.go`** — *load-bearing safety fix*
  - `deleteValidatorInternal` now only deletes the cons-addr→operator index entry **if it still points to this validator**. Without this guard, the EndBlocker cleanup of the stale validator would unconditionally `store.Delete(GetValidatorByConsAddrKey(consAddr))`, orphaning the index entry that the new validator just took ownership of via `SetValidatorByConsAddr` in the same block. Lookups by consensus address (slashing, evidence, jailing) would then fail to resolve the new validator.

## Test plan

Run from `gonka-ai/cosmos-sdk` root:

```
go test ./x/staking/keeper/ -run 'TestSortAndFilter|TestFilterBasedOnExisting|TestDeleteValidatorInternal' -v
```

New tests:

- `TestFilterBasedOnExisting_StaleConsensusKeyConflict` — Change 1, stale path passes through
- `TestFilterBasedOnExisting_NonStaleConsensusKeyConflict` — Change 1, active path still rejected
- `TestFilterBasedOnExisting_StaleOperatorKeyChange` — Change 2, stale path passes through
- `TestFilterBasedOnExisting_NonStaleOperatorKeyChange` — Change 2, active path still rejected
- `TestDeleteValidatorInternal_PreservesReassignedConsAddrIndex` — defensive cons-addr check: when index has been reassigned, stale cleanup leaves the new owner's pointer intact
- `TestDeleteValidatorInternal_DeletesUnreassignedConsAddrIndex` — defensive check doesn't break the normal cleanup path

Existing tests:
- `TestSortAndFilterComputeResult_FromJSON` and `TestSortAndFilterComputeResult_FiltersAgainstExisting` updated for the new return signature; existing rejection-path assertions preserved by giving the test's existing validator non-zero tokens.

Pre-existing failures on `release/v0.53.x` (unrelated to this PR — MockBankKeeper expectation mismatches in `delegation_test.go` / `validator_test.go`) are unchanged.

## Affected addresses (post-deploy verification)

Per the Linear ticket — these should start receiving staking power after this fix is deployed:
- `gonka1vjz8csqsr0ph0lv0yylc4auypnzrld7y6l2feu`
- `gonka1duuaqdx06sx8v2dzggltwwmqyuw8lvjkjq7xll`

## Downstream

`inference-chain` builds cleanly against this fork (verified locally with a temporary `replace` directive). After merge, a new fork tag (`v0.53.3-ps20`?) and a bump in `inference-chain/go.mod` are needed for the v0.2.14 upgrade.