### PR TITLE
fix(staking): prevent chain-halt in markValidatorForDeletion jailed branch

### DIFF
--- a/x/staking/keeper/compute.go
+++ b/x/staking/keeper/compute.go
@@ -556,10 +556,29 @@ func (k Keeper) markValidatorForDeletion(ctx context.Context, validator types.Va
 		return err
 	}
 
-	// Jailed validators can't be added to power index, so delete them immediately
+	// Jailed validators can't be added to the power index. Zero out Tokens
+	// (the PoC power proxy) but KEEP DelegatorShares so TokensFromShares =
+	// shares × Tokens / DelegatorShares returns 0 cleanly — preventing a
+	// divide-by-zero panic if slashing.Unjail later runs on this stale
+	// validator before DeleteZeroPowerValidators removes it.
+	//
+	// jailValidator (val_state_change.go) already removed this validator from
+	// the power index, so ApplyAndReturnValidatorSetUpdates's main loop won't
+	// iterate it. The tail loop over LastValidatorPower emits the power-0
+	// ValidatorUpdate, and DeleteZeroPowerValidators physically removes the
+	// record on the next block — after LastValidatorPower has been cleared
+	// and CometBFT has been told to drop the validator from its active set.
+	//
+	// Deleting the record immediately (the previous behavior) wiped the
+	// ValidatorByConsAddr index while CometBFT still included the validator
+	// in LastCommit for ValidatorUpdateDelay blocks, causing
+	// slashing.BeginBlocker to halt the chain with ErrNoValidatorFound on
+	// the next block (#1205).
 	if validator.Jailed {
-		logger.Info("deleting jailed validator immediately", "operator", validator.OperatorAddress)
-		return k.deleteValidatorInternal(ctx, validator, valAddr)
+		logger.Info("zero-tokens jailed validator for next-block cleanup", "operator", validator.OperatorAddress)
+		validator.Tokens = math.ZeroInt()
+		validator.UnbondingIds = []uint64{}
+		return k.SetValidator(ctx, validator)
 	}
 
 	// For non-jailed validators, mark for deletion in next block

--- a/x/staking/keeper/mark_validator_for_deletion_test.go
+++ b/x/staking/keeper/mark_validator_for_deletion_test.go
@@ -1,0 +1,81 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
+)
+
+// TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable asserts
+// that when SetComputeValidators removes a jailed validator, the validator's
+// consensus-address index remains reachable. CometBFT continues to include
+// the validator in LastCommit for ValidatorUpdateDelay blocks after the
+// staking module decides to remove it (= header.Height + 1 + 1 per cometbft
+// state/execution.go, matching the NextValidators double-buffer), and during
+// that window slashing.BeginBlocker → IsValidatorJailed →
+// GetValidatorByConsAddr must succeed — otherwise the chain halts with
+// ErrNoValidatorFound on the very next block.
+//
+// On current code this test FAILS: the jailed branch of
+// markValidatorForDeletion (compute.go:559-563) routes through
+// deleteValidatorInternal, which wipes the staking record AND the
+// ValidatorByConsAddr index immediately, while CometBFT is still sending
+// votes for the validator. The non-jailed branch (compute.go:565-598) keeps
+// the record at zero power, so it does not have this problem.
+func (s *KeeperTestSuite) TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	// Position past ValidatorIndexFixHeight so we exercise the post-fix path.
+	ctx = ctx.WithBlockHeight(stakingkeeper.ValidatorIndexFixHeight + 1)
+
+	valPubKey := PKs[0]
+	valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
+	consAddr := sdk.ConsAddress(valPubKey.Address())
+	valTokens := keeper.TokensFromConsensusPower(ctx, 10)
+
+	validator := testutil.NewValidator(s.T(), valAddr, valPubKey)
+	validator, _ = validator.AddTokensFromDel(valTokens)
+	require.NoError(keeper.SetValidator(ctx, validator))
+	require.NoError(keeper.SetValidatorByPowerIndex(ctx, validator))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, validator))
+
+	// Unbonded -> Bonded. gonka's NoOpBankKeeper (keeper.go:113) swallows
+	// pool transfers, so no bank EXPECT is needed.
+	_, err := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
+	require.NoError(err)
+
+	// Pre-condition: the validator is reachable via consensus address.
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err)
+
+	// Jail the validator. jailValidator also calls DeleteValidatorByPowerIndex,
+	// so afterwards it is in the store with Jailed=true but not in the power
+	// index. Crucially the record AND the ValidatorByConsAddr index still
+	// exist — matching CometBFT's view that this validator is still in the
+	// active set.
+	require.NoError(keeper.Jail(ctx, consAddr))
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err, "Jail itself must not wipe the index")
+
+	// Drop the jailed validator from compute results. This is the operation
+	// under test — markValidatorForDeletion takes the jailed branch.
+	_, err = keeper.SetComputeValidators(ctx, []stakingkeeper.ComputeResult{}, true)
+	require.NoError(err)
+
+	// === The assertion under test (FAILS on current code) =================
+	// At this point CometBFT still has the validator in its active set and
+	// will continue to include it in LastCommit for ValidatorUpdateDelay
+	// blocks. slashing.BeginBlocker walks each vote and calls
+	// GetValidatorByConsAddr — that lookup MUST succeed; otherwise the chain
+	// halts. Therefore the index must NOT be wiped immediately when the
+	// staking module decides to remove the validator.
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err,
+		"jailed-validator removal must not wipe the ValidatorByConsAddr "+
+			"index immediately: CometBFT continues to include the validator "+
+			"in LastCommit for ValidatorUpdateDelay blocks, and slashing's "+
+			"GetValidatorByConsAddr lookups must succeed during that "+
+			"window — otherwise BeginBlocker halts the chain with "+
+			"ErrNoValidatorFound.")
+}

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -303,19 +303,34 @@ func (v Validator) InvalidExRate() bool {
 	return v.Tokens.IsZero() && v.DelegatorShares.IsPositive()
 }
 
-// calculate the token worth of provided shares
+// calculate the token worth of provided shares.
+// Returns zero when DelegatorShares is zero — symmetric with
+// SharesFromTokens's guard for Tokens.IsZero — to avoid a divide-by-zero
+// panic on stale validators whose tokens have been zeroed for next-block
+// cleanup (see #1205).
 func (v Validator) TokensFromShares(shares math.LegacyDec) math.LegacyDec {
+	if v.DelegatorShares.IsZero() {
+		return math.LegacyZeroDec()
+	}
 	return (shares.MulInt(v.Tokens)).Quo(v.DelegatorShares)
 }
 
-// calculate the token worth of provided shares, truncated
+// calculate the token worth of provided shares, truncated.
+// See TokensFromShares for the DelegatorShares=0 defensive guard rationale.
 func (v Validator) TokensFromSharesTruncated(shares math.LegacyDec) math.LegacyDec {
+	if v.DelegatorShares.IsZero() {
+		return math.LegacyZeroDec()
+	}
 	return (shares.MulInt(v.Tokens)).QuoTruncate(v.DelegatorShares)
 }
 
 // TokensFromSharesRoundUp returns the token worth of provided shares, rounded
 // up.
+// See TokensFromShares for the DelegatorShares=0 defensive guard rationale.
 func (v Validator) TokensFromSharesRoundUp(shares math.LegacyDec) math.LegacyDec {
+	if v.DelegatorShares.IsZero() {
+		return math.LegacyZeroDec()
+	}
 	return (shares.MulInt(v.Tokens)).QuoRoundUp(v.DelegatorShares)
 }
 

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -86,6 +86,30 @@ func TestShareTokens(t *testing.T) {
 	assert.True(math.LegacyDecEq(t, math.LegacyNewDec(5), validator.TokensFromShares(math.LegacyNewDec(10))))
 }
 
+// TestShareTokens_ZeroDelegatorShares verifies the defensive guard against
+// divide-by-zero when DelegatorShares is zero — symmetric with the existing
+// SharesFromTokens guard for Tokens=0. Without the guard, slashing.Unjail on
+// a stale validator zeroed for next-block cleanup would panic through
+// TokensFromShares (see #1205).
+func TestShareTokens_ZeroDelegatorShares(t *testing.T) {
+	validator := mkValidator(100, math.LegacyNewDec(100))
+	validator.Tokens = math.ZeroInt()
+	validator.DelegatorShares = math.LegacyZeroDec()
+
+	require.NotPanics(t, func() {
+		got := validator.TokensFromShares(math.LegacyNewDec(50))
+		assert.True(math.LegacyDecEq(t, math.LegacyZeroDec(), got))
+	})
+	require.NotPanics(t, func() {
+		got := validator.TokensFromSharesTruncated(math.LegacyNewDec(50))
+		assert.True(math.LegacyDecEq(t, math.LegacyZeroDec(), got))
+	})
+	require.NotPanics(t, func() {
+		got := validator.TokensFromSharesRoundUp(math.LegacyNewDec(50))
+		assert.True(math.LegacyDecEq(t, math.LegacyZeroDec(), got))
+	})
+}
+
 func TestRemoveTokens(t *testing.T) {
 	validator := mkValidator(100, math.LegacyNewDec(100))
 


### PR DESCRIPTION
# Summary

Fix for the chain-halt race in `markValidatorForDeletion`'s jailed branch reported in [gonka-ai/gonka#1205](https://github.com/gonka-ai/gonka/issues/1205) by @vitaly-andr. Mainnet-vulnerable on the current production pin (`v0.53.3-ps17`) and on every subsequent tag through `v0.53.3-ps19`.

# Root cause

The jailed branch of `markValidatorForDeletion` (`x/staking/keeper/compute.go:559-563`) routed through `deleteValidatorInternal`, which wiped the validator record **and** the `ValidatorByConsAddr` index in the same `EndBlock` — with no `ValidatorUpdate` signalled to CometBFT.

CometBFT, however, continues to include the validator in `LastCommit` for `ValidatorUpdateDelay` blocks (≈ 2 effective blocks, `header.Height + 1 + 1` per cometbft `state/execution.go`). On the next block `slashing.BeginBlocker` walked those votes and called `HandleValidatorSignature → GetValidatorByConsAddr` (`x/slashing/keeper/infractions.go:26-30`). The lookup returned `stakingtypes.ErrNoValidatorFound` → `BeginBlocker` returned an error → consensus halted.

`RestoreValidatorIndex` does not cover this: it iterates `GetAllValidators()` and restores a missing `ValidatorByConsAddr` entry only when the underlying validator record still exists. Here the record itself is gone.

# Fixes

**Primary (`x/staking/keeper/compute.go`, jailed branch):** zero out `Tokens` (the PoC power proxy) but keep `DelegatorShares`. `ApplyAndReturnValidatorSetUpdates`'s tail loop over `LastValidatorPower` then emits the power-0 `ValidatorUpdate` so CometBFT drops the validator from its active set on the next block, and `DeleteZeroPowerValidators` physically removes the record afterwards — after `LastValidatorPower` has been cleared and CometBFT has been told to drop the validator.

`DelegatorShares` is intentionally **not** zeroed: `TokensFromShares = shares × Tokens / DelegatorShares`, and dividing by zero panics. Keeping `DelegatorShares` non-zero with `Tokens = 0` returns 0 cleanly.

**Secondary (`x/staking/types/validator.go`):** defensive `DelegatorShares.IsZero()` guard on `TokensFromShares` / `TokensFromSharesTruncated` / `TokensFromSharesRoundUp` — symmetric with the existing `Tokens.IsZero()` guard on `SharesFromTokens`. Prevents the divide-by-zero panic the issue flagged: a concurrent `MsgUnjail` landing in the same block as the non-jailed deletion path (which still zeroes `DelegatorShares` at `compute.go:573`) would otherwise panic via `Validator.TokensFromShares` reached from `slashing.Unjail`. On mainnet this is currently masked by `DeleteZeroPowerValidators` cleaning the validator up on the next block, but the window exists.

# Tests

| Test | Where | Verifies |
|------|-------|---------|
| `TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable` | `x/staking/keeper/mark_validator_for_deletion_test.go` | Regression test from the reporter's gist ([vitaly-andr/83816dc3704211a6720edbf63b45761c](https://gist.github.com/vitaly-andr/83816dc3704211a6720edbf63b45761c)). Asserts that after `SetComputeValidators` drops a jailed validator, `GetValidatorByConsAddr` still resolves it. Red on current code (`validator does not exist`), green with the primary fix. |
| `TestShareTokens_ZeroDelegatorShares` | `x/staking/types/validator_test.go` | Covers the defensive guard on all three `TokensFromShares*` variants. |

Verified on `v0.53.3-ps17`:

- `x/staking/types` suite: all PASS (including the new defensive guard test).
- `x/staking/keeper` suite: 28 PASS, 21 pre-existing FAIL — every FAIL is a `NoOpBankKeeper`-related test (delegate/undelegate/redelegate/unbond), identical with and without this patch (verified via `git stash`). `compute_test.go` (the touched zone) — all PASS.
- `go vet ./x/staking/...` and `go build ./x/staking/...` — clean.

# Coordination with [#14 (GON-191)](https://github.com/gonka-ai/cosmos-sdk/pull/14)

Symbiotic but orthogonal — verified line-by-line:

- #14 modifies `filterBasedOnExisting`, `sortAndFilterComputeResult` and the cons-addr deletion guard inside `deleteValidatorInternal`.
- This PR modifies only the jailed branch of `markValidatorForDeletion` (and adds the defensive `TokensFromShares` guard in `x/staking/types/validator.go`).

The two PRs do not touch the same lines and compose cleanly. The reporter's empirical run showed both fixes are needed:

- With this fix alone: the halt is cleared but the sim later SKIPs «empty validator set» (the path #14 closes).
- With #14 alone: the chain still halts at the same trigger point.
- With both: full sim runs to completion, deterministic `AppHash` across both top-level sim tests.

Happy to land in either order — recommend coordinated.

# Credits

Analysis, root-cause investigation and the regression-test gist by @vitaly-andr in gonka-ai/gonka#1205. This PR implements the candidate fix described in that report and adds the secondary defensive guard the report also flagged.

# Refs

Closes: gonka-ai/gonka#1205
Related: #14 (GON-191)
