### PR TITLE
fix(staking): harden markValidatorForDeletion (jailed-delete race + non-jailed divide-by-zero)

### DIFF
--- a/x/staking/keeper/compute.go
+++ b/x/staking/keeper/compute.go
@@ -556,10 +556,33 @@ func (k Keeper) markValidatorForDeletion(ctx context.Context, validator types.Va
 		return err
 	}
 
-	// Jailed validators can't be added to power index, so delete them immediately
+	// For jailed validators: zero out Tokens (the power proxy in PoC) and
+	// persist. Do NOT re-add to the power index (val_state_change.go:176
+	// invariant forbids jailed-in-power-store) and do NOT zero
+	// DelegatorShares — TokensFromShares (validator.go:308) computes
+	// `shares × Tokens / DelegatorShares`, and a zero denominator triggers a
+	// runtime divide-by-zero panic if any caller (e.g. slashing.Unjail at
+	// unjail.go:33) hits this validator before DeleteZeroPowerValidators
+	// cleans it up. With Tokens=0 and DelegatorShares unchanged, the formula
+	// returns 0 cleanly.
+	//
+	// jailValidator (val_state_change.go:335) already removed the validator
+	// from the power index, so ApplyAndReturnValidatorSetUpdates' main loop
+	// won't iterate it. The tail loop over `last` (LastValidatorPower) will
+	// emit the power-0 ValidatorUpdate and start the bondedToUnbonding
+	// transition. DeleteZeroPowerValidators will physically remove the
+	// record on a later block after LastValidatorPower is cleared, by which
+	// time CometBFT has dropped the validator from its active set.
 	if validator.Jailed {
-		logger.Info("deleting jailed validator immediately", "operator", validator.OperatorAddress)
-		return k.deleteValidatorInternal(ctx, validator, valAddr)
+		validator.Tokens = math.ZeroInt()
+		validator.UnbondingIds = []uint64{}
+
+		if err := k.SetValidator(ctx, validator); err != nil {
+			logger.Error("failed to set jailed validator with zero power", "validator", validator.OperatorAddress, "error", err)
+			return err
+		}
+
+		return nil
 	}
 
 	// For non-jailed validators, mark for deletion in next block
@@ -568,9 +591,14 @@ func (k Keeper) markValidatorForDeletion(ctx context.Context, validator types.Va
 		return err
 	}
 
-	// Set power to zero (status kept as-is for ApplyAndReturnValidatorSetUpdates)
+	// Set power to zero (status kept as-is for ApplyAndReturnValidatorSetUpdates).
+	// Do NOT zero DelegatorShares: TokensFromShares (validator.go:308) computes
+	// `shares × Tokens / DelegatorShares`, so a zero denominator panics if a
+	// caller (e.g. slashing.Unjail) hits this validator in the same block,
+	// before DeleteZeroPowerValidators removes it on the next block. Tokens=0
+	// already yields zero power; keeping DelegatorShares makes TokensFromShares
+	// return 0 cleanly. Same fix shape as the jailed branch above.
 	validator.Tokens = math.ZeroInt()
-	validator.DelegatorShares = math.LegacyZeroDec()
 	validator.UnbondingIds = []uint64{}
 
 	if err := k.SetValidator(ctx, validator); err != nil {

--- a/x/staking/keeper/mark_validator_for_deletion_test.go
+++ b/x/staking/keeper/mark_validator_for_deletion_test.go
@@ -1,0 +1,128 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
+)
+
+// TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable asserts
+// that when SetComputeValidators removes a jailed validator, the validator's
+// consensus-address index remains reachable. CometBFT continues to include
+// the validator in LastCommit for ValidatorUpdateDelay blocks after the
+// staking module decides to remove it (= header.Height + 1 + 1 per cometbft
+// state/execution.go, matching the NextValidators double-buffer), and during
+// that window slashing.BeginBlocker → IsValidatorJailed →
+// GetValidatorByConsAddr must succeed — otherwise the chain halts with
+// ErrNoValidatorFound on the very next block.
+//
+// On current code this test FAILS: the jailed branch of
+// markValidatorForDeletion (compute.go:559-563) routes through
+// deleteValidatorInternal, which wipes the staking record AND the
+// ValidatorByConsAddr index immediately, while CometBFT is still sending
+// votes for the validator. The non-jailed branch (compute.go:565-598) keeps
+// the record at zero power, so it does not have this problem.
+func (s *KeeperTestSuite) TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	// Position past ValidatorIndexFixHeight so we exercise the post-fix path.
+	ctx = ctx.WithBlockHeight(stakingkeeper.ValidatorIndexFixHeight + 1)
+
+	valPubKey := PKs[0]
+	valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
+	consAddr := sdk.ConsAddress(valPubKey.Address())
+	valTokens := keeper.TokensFromConsensusPower(ctx, 10)
+
+	validator := testutil.NewValidator(s.T(), valAddr, valPubKey)
+	validator, _ = validator.AddTokensFromDel(valTokens)
+	require.NoError(keeper.SetValidator(ctx, validator))
+	require.NoError(keeper.SetValidatorByPowerIndex(ctx, validator))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, validator))
+
+	// Unbonded -> Bonded. gonka's NoOpBankKeeper (keeper.go:113) swallows
+	// pool transfers, so no bank EXPECT is needed.
+	_, err := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
+	require.NoError(err)
+
+	// Pre-condition: the validator is reachable via consensus address.
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err)
+
+	// Jail the validator. jailValidator also calls DeleteValidatorByPowerIndex,
+	// so afterwards it is in the store with Jailed=true but not in the power
+	// index. Crucially the record AND the ValidatorByConsAddr index still
+	// exist — matching CometBFT's view that this validator is still in the
+	// active set.
+	require.NoError(keeper.Jail(ctx, consAddr))
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err, "Jail itself must not wipe the index")
+
+	// Drop the jailed validator from compute results. This is the operation
+	// under test — markValidatorForDeletion takes the jailed branch.
+	_, err = keeper.SetComputeValidators(ctx, []stakingkeeper.ComputeResult{}, true)
+	require.NoError(err)
+
+	// === The assertion under test (FAILS on current code) =================
+	// At this point CometBFT still has the validator in its active set and
+	// will continue to include it in LastCommit for ValidatorUpdateDelay
+	// blocks. slashing.BeginBlocker walks each vote and calls
+	// GetValidatorByConsAddr — that lookup MUST succeed; otherwise the chain
+	// halts. Therefore the index must NOT be wiped immediately when the
+	// staking module decides to remove the validator.
+	_, err = keeper.GetValidatorByConsAddr(ctx, consAddr)
+	require.NoError(err,
+		"jailed-validator removal must not wipe the ValidatorByConsAddr "+
+			"index immediately: CometBFT continues to include the validator "+
+			"in LastCommit for ValidatorUpdateDelay blocks, and slashing's "+
+			"GetValidatorByConsAddr lookups must succeed during that "+
+			"window — otherwise BeginBlocker halts the chain with "+
+			"ErrNoValidatorFound.")
+}
+
+// TestMarkValidatorForDeletion_NonJailedRemoval_KeepsDelegatorShares asserts
+// that when SetComputeValidators removes a NON-jailed validator, the
+// validator's DelegatorShares are preserved (only Tokens are zeroed).
+//
+// On current code this test FAILS: the non-jailed branch of
+// markValidatorForDeletion zeros DelegatorShares alongside Tokens. Because
+// TokensFromShares (validator.go:308) divides by DelegatorShares, a MsgUnjail
+// (or any other TokensFromShares caller) landing in the same block as the
+// marking — before DeleteZeroPowerValidators removes the record on the next
+// block — hits a divide-by-zero panic. Keeping DelegatorShares non-zero with
+// Tokens=0 makes TokensFromShares return 0 cleanly. Confirmed by @0xgonka on
+// gonka-ai/cosmos-sdk#14: same fix shape as the jailed branch.
+func (s *KeeperTestSuite) TestMarkValidatorForDeletion_NonJailedRemoval_KeepsDelegatorShares() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	ctx = ctx.WithBlockHeight(stakingkeeper.ValidatorIndexFixHeight + 1)
+
+	valPubKey := PKs[1]
+	valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
+	valTokens := keeper.TokensFromConsensusPower(ctx, 10)
+
+	validator := testutil.NewValidator(s.T(), valAddr, valPubKey)
+	validator, _ = validator.AddTokensFromDel(valTokens)
+	require.NoError(keeper.SetValidator(ctx, validator))
+	require.NoError(keeper.SetValidatorByPowerIndex(ctx, validator))
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, validator))
+
+	_, err := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
+	require.NoError(err)
+
+	// Drop the (non-jailed) validator from compute results — exercises the
+	// non-jailed branch of markValidatorForDeletion.
+	_, err = keeper.SetComputeValidators(ctx, []stakingkeeper.ComputeResult{}, true)
+	require.NoError(err)
+
+	got, err := keeper.GetValidator(ctx, valAddr)
+	require.NoError(err)
+	require.True(got.Tokens.IsZero(), "tokens must be zeroed for mark-for-deletion")
+	require.False(got.DelegatorShares.IsZero(),
+		"DelegatorShares must be preserved: TokensFromShares divides by it, so a "+
+			"zero denominator panics if slashing.Unjail hits this validator before "+
+			"DeleteZeroPowerValidators removes it next block")
+	require.NotPanics(func() { _ = got.TokensFromShares(got.DelegatorShares) },
+		"TokensFromShares must not divide by zero on a marked validator")
+}


### PR DESCRIPTION
`markValidatorForDeletion` mishandled validator removal in **both** branches. Same function, same defect class (zeroing state in a way that breaks downstream consumers before the record is gone), so fixed together.

## 1. Jailed branch — chain halt

The jailed branch called `deleteValidatorInternal`, removing the validator record **and** the `ValidatorByConsAddr` index immediately. CometBFT keeps the validator in `LastCommit` for `ValidatorUpdateDelay` blocks (effective 2-block lag — `state/execution.go` next-next-height plus the `NextValidators` double-buffer). During that window `slashing.BeginBlocker → IsValidatorJailed → GetValidatorByConsAddr` fails with `ErrNoValidatorFound`, halting the chain.

## 2. Non-jailed branch — divide-by-zero panic

The non-jailed branch zeroed `DelegatorShares` alongside `Tokens`. `TokensFromShares` (`validator.go:308`) computes `shares × Tokens / DelegatorShares`, so a `MsgUnjail` (or any other `TokensFromShares` caller) landing in the same block as the marking — before `DeleteZeroPowerValidators` removes the record on the next block — hits a divide-by-zero panic.

## Fix

Both paths now zero `Tokens` but keep `DelegatorShares` (and, for the jailed path, keep the record + index). Power becomes zero, the existing `DeleteZeroPowerValidators` defer-path removes the record on a later block — after `LastValidatorPower` clears and CometBFT has dropped the validator — and `TokensFromShares` returns 0 cleanly.

## Tests

- `TestMarkValidatorForDeletion_JailedRemoval_KeepsValidatorReachable`
- `TestMarkValidatorForDeletion_NonJailedRemoval_KeepsDelegatorShares`

Both fail on current `release/v0.53.x` and pass with the fix.

## Context

Surfaced while implementing simulation/fuzz testing for inference-chain (gonka-ai/gonka#982); filed with a standalone reproducer as gonka-ai/gonka#1205.

Independent of and complementary to GON-191 (#14, @0xgonka) — a different function (`markValidatorForDeletion`) than GON-191's (`filterBasedOnExisting` / `deleteValidatorInternal`). The two were verified to compose without conflict (full simulation pass with both patches, height=501); coordination on #14: https://github.com/gonka-ai/cosmos-sdk/pull/14#issuecomment-4494014869. In that thread @0xgonka confirmed the non-jailed divide-by-zero (#2 above) and recommended fixing it in this PR (identical fix shape).

cc @gmorgachev — fork maintainer and author of `markValidatorForDeletion` (both branches changed here: the jailed delete in `cefc31d3a8e`, the non-jailed `DelegatorShares` zeroing in `0d28c0a1e2e`)
