### PR TITLE
fix(staking): skip tombstoned validators in epoch compute recompute

### DIFF
--- a/x/staking/keeper/compute.go
+++ b/x/staking/keeper/compute.go
@@ -96,6 +96,11 @@ func (k Keeper) SetComputeValidatorsBeforeValidatorIndexFixHeight(ctx context.Co
 	return k.GetAllValidators(ctx)
 }
 
+// TombstoneChecker reports whether the validator with the given consensus address is
+// tombstoned in the slashing module. Injected via Keeper.SetTombstoneChecker so the
+// epoch recompute can keep a permanently-banned validator out of the active set.
+type TombstoneChecker func(ctx context.Context, consAddr sdk.ConsAddress) bool
+
 // SetComputeValidators is the main entry point for updating the validator set.
 // It synchronizes the state with the provided list of compute results.
 func (k Keeper) SetComputeValidators(
@@ -166,6 +171,16 @@ func (k Keeper) SetComputeValidators(
 		result := resultsByOperatorAddress[operatorAddress]
 		val, found := currentValsByOperatorAddress[operatorAddress]
 		power := math.NewInt(result.Power)
+
+		// Skip a tombstoned validator: don't route it through updateValidator, which would
+		// unjail and re-bond it. Intentionally not markValidatorForDeletion either — its jailed
+		// branch deletes the ValidatorByConsAddr index and can halt slashing while the validator
+		// is still in CometBFT's LastCommit (see gonka-ai/gonka#1205).
+		if k.tombstoneChecker != nil && result.ValidatorPubKey != nil &&
+			k.tombstoneChecker(ctx, sdk.ConsAddress(result.ValidatorPubKey.Address())) {
+			logger.Info("skipping tombstoned validator in compute recompute (not resurrecting)", "operator", operatorAddress)
+			continue
+		}
 
 		if !found {
 			logger.Info("creating new validator", "pubkey", result.ValidatorPubKey.Address(), "power", power)

--- a/x/staking/keeper/compute_tombstone_test.go
+++ b/x/staking/keeper/compute_tombstone_test.go
@@ -1,0 +1,85 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtestutil "github.com/cosmos/cosmos-sdk/x/staking/testutil"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// TestSetComputeValidators_SkipsTombstonedValidator checks that, when a tombstone checker is
+// wired, the epoch validator-set recompute does not unjail or re-bond a validator the
+// slashing module reports as tombstoned. The record is left in place (jailed, unbonded, zero
+// power) rather than being routed through updateValidator.
+func TestSetComputeValidators_SkipsTombstonedValidator(t *testing.T) {
+	key := storetypes.NewKVStoreKey(stakingtypes.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_tombstone"))
+	ctx := testCtx.Ctx
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+
+	ctrl := gomock.NewController(t)
+	ak := stakingtestutil.NewMockAccountKeeper(ctrl)
+	ak.EXPECT().GetModuleAddress(stakingtypes.BondedPoolName).Return(bondedAcc.GetAddress()).AnyTimes()
+	ak.EXPECT().GetModuleAddress(stakingtypes.NotBondedPoolName).Return(notBondedAcc.GetAddress()).AnyTimes()
+	ak.EXPECT().AddressCodec().Return(address.NewBech32Codec("cosmos")).AnyTimes()
+	bk := stakingtestutil.NewMockBankKeeper(ctrl)
+
+	k := stakingkeeper.NewKeeper(
+		encCfg.Codec, storeService, ak, bk,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		address.NewBech32Codec("cosmosvaloper"),
+		address.NewBech32Codec("cosmosvalcons"),
+	)
+	require.NoError(t, k.SetParams(ctx, stakingtypes.DefaultParams()))
+	stakingtypes.RegisterInterfaces(encCfg.InterfaceRegistry)
+
+	consPk := PKs[0]
+	valAddr := sdk.ValAddress(PKs[1].Address())
+	tombstoned := sdk.ConsAddress(consPk.Address())
+	k.SetTombstoneChecker(func(_ context.Context, consAddr sdk.ConsAddress) bool {
+		return consAddr.Equals(tombstoned)
+	})
+
+	v, err := stakingtypes.NewValidator(valAddr.String(), consPk, stakingtypes.Description{Moniker: "tombstoned"})
+	require.NoError(t, err)
+	v.Jailed = true
+	v.Status = stakingtypes.Unbonded
+	v.Tokens = math.ZeroInt()
+	v.DelegatorShares = math.LegacyZeroDec()
+	require.NoError(t, k.SetValidator(ctx, v))
+	require.NoError(t, k.SetValidatorByConsAddr(ctx, v))
+
+	cr := []stakingkeeper.ComputeResult{{OperatorAddress: valAddr.String(), ValidatorPubKey: consPk, Power: 100}}
+	_, err = k.SetComputeValidators(ctx, cr, true)
+	require.NoError(t, err)
+
+	after, err := k.GetValidator(ctx, valAddr)
+	require.NoError(t, err)
+	require.True(t, after.Jailed, "tombstoned validator must stay jailed")
+	require.False(t, after.IsBonded(), "tombstoned validator must not be re-bonded")
+	require.True(t, after.Tokens.IsZero(), "tombstoned validator must not regain power")
+
+	// Halt-safety: evidence/slashing BeginBlock resolves validators by consensus address.
+	// If the recompute had physically removed this record, GetValidatorByConsAddr would
+	// return ErrNoValidatorFound and FinalizeBlock would halt the chain. The skip is a
+	// no-op continue that never deletes, so the cons-addr index still resolves.
+	byCons, err := k.GetValidatorByConsAddr(ctx, tombstoned)
+	require.NoError(t, err, "tombstoned validator must stay resolvable by cons addr (no evidence/slashing halt)")
+	require.Equal(t, valAddr.String(), byCons.OperatorAddress)
+}

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -79,6 +79,9 @@ type Keeper struct {
 	authority             string
 	validatorAddressCodec addresscodec.Codec
 	consensusAddressCodec addresscodec.Codec
+	// tombstoneChecker, when set, reports whether a validator is tombstoned in the
+	// slashing module. Injected via SetTombstoneChecker to avoid a circular import.
+	tombstoneChecker TombstoneChecker
 }
 
 // NewKeeper creates a new staking Keeper instance
@@ -148,6 +151,14 @@ func (k *Keeper) SetHooks(sh types.StakingHooks) {
 	}
 
 	k.hooks = sh
+}
+
+// SetTombstoneChecker injects a function reporting whether a validator (by consensus
+// address) is tombstoned in the slashing module. The epoch validator-set recompute
+// (SetComputeValidators) uses it so a permanently-banned (e.g. equivocating) validator
+// is not resurrected. Wired in app setup once the slashing keeper exists; nil = unchanged.
+func (k *Keeper) SetTombstoneChecker(fn TombstoneChecker) {
+	k.tombstoneChecker = fn
 }
 
 // GetLastTotalPower loads the last total validator power.


### PR DESCRIPTION
@gmorgachev **this is the "we should reject tombstone too" point from chat.** the epoch validator-set recompute (`SetComputeValidators` → `updateValidator`) sets every validator it processes to bonded with jailed=false at the compute power, with no check against the slashing tombstone. so a validator that got tombstoned for double-signing — which on-chain is jailed + unbonded — gets unjailed and re-bonded at full power on the next epoch, as long as it's still in the compute results. it comes back every epoch.

that defeats the permanent equivocation ban. co
smos `MsgUnjail` refuses a tombstoned validator on purpose; this path has no equivalent gate. and collateral slashing on gonka only covers invalidation + downtime, not equivocation — so the cosmos tombstone is the only permanent deterrent for double-signing, and this bypasses it.

fix is opt-in, nil checker = unchanged behaviour. keeper.go gets a `tombstoneChecker` field and a `SetTombstoneChecker` setter (mirrors SetHooks). compute.go: when a checker is wired and the result's validator is tombstoned, it's skipped — just a `continue`, so it never goes through `updateValidator` and never gets unjailed or re-bonded. if the checker is never wired, behaviour is identical to today.

skip-only on purpose — i deliberately don't call `markValidatorForDeletion` to evict it. that function's jailed branch deletes the `ValidatorByConsAddr` index right away, which can halt the chain while cometbft still has the validator in LastCommit (gonka-ai/gonka#1205 / the evidence-slashing halt #16 is fixing). the skip is a plain `continue` in the create/update loop — it never deletes — so it's orthogonal to #14 / #16: a tombstoned validator in the compute results is neither evicted nor resurrected, the record stays put. they edit the same compute.go but different regions, so happy to rebase on whichever lands first.

the actual wiring — `app.StakingKeeper.SetTombstoneChecker(app.SlashingKeeper.IsTombstoned)` — goes in the gonka app.go as a follow-up once this is tagged, since it can't compile until this is a released dep.

test included: `TestSetComputeValidators_SkipsTombstonedValidator` — asserts the tombstoned validator stays jailed/unbonded/zero-power and stays resolvable by cons-addr, so the evidence/slashing BeginBlock lookup doesn't hit `ErrNoValidatorFound`. also reproduced end-to-end against the full gonka app: tombstone a validator the real way (signing info + jail + `Tombstone`), run the recompute, and it comes back bonded + unjailed while `IsTombstoned` still reports true.
