### PR TITLE
feat(baseapp): add gonka_query_* metrics and slow-query log

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -183,6 +183,7 @@ func (app *BaseApp) Query(_ context.Context, req *abci.RequestQuery) (resp *abci
 	gonkaQueryInFlight.WithLabelValues(gonkaRec.method, gonkaRec.transport).Inc()
 	defer gonkaQueryInFlight.WithLabelValues(gonkaRec.method, gonkaRec.transport).Dec()
 	defer func() {
+		gonkaRec.currentHeight = app.LastBlockHeight()
 		gonkaRec.totalDuration = time.Since(gonkaRec.start)
 		switch {
 		case resp != nil:

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -167,6 +167,36 @@ func (app *BaseApp) Query(_ context.Context, req *abci.RequestQuery) (resp *abci
 	telemetry.IncrCounter(1, "query", req.Path)
 	defer telemetry.MeasureSince(telemetry.Now(), req.Path)
 
+	// Gonka: full Prometheus instrumentation for the ABCI query path. Pairs
+	// with the gRPC interceptor in grpcserver.go so REST/gRPC/ABCI all share
+	// the same gonka_query_* series, separated by the transport label.
+	gonkaRec := gonkaQueryRecord{
+		method:          req.Path,
+		transport:       GonkaTransportABCI,
+		peer:            GonkaPeerABCI,
+		start:           time.Now(),
+		respBytes:       -1,
+		requestedHeight: req.Height,
+		currentHeight:   app.LastBlockHeight(),
+		requestSummary:  fmt.Sprintf("path=%s height=%d data=%dB prove=%v", req.Path, req.Height, len(req.Data), req.Prove),
+	}
+	gonkaQueryInFlight.WithLabelValues(gonkaRec.method, gonkaRec.transport).Inc()
+	defer gonkaQueryInFlight.WithLabelValues(gonkaRec.method, gonkaRec.transport).Dec()
+	defer func() {
+		gonkaRec.totalDuration = time.Since(gonkaRec.start)
+		switch {
+		case resp != nil:
+			gonkaRec.status = gonkaClassifyABCICode(resp.Code)
+			gonkaRec.respBytes = len(resp.Value)
+		case err != nil:
+			gonkaRec.status = "error"
+		default:
+			gonkaRec.status = "ok"
+		}
+		gonkaObserve(gonkaRec)
+		gonkaMaybeSlowLog(app.logger, gonkaRec)
+	}()
+
 	if req.Path == QueryPathBroadcastTx {
 		return sdkerrors.QueryResult(errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "can't route a broadcast tx message"), app.trace), nil
 	}
@@ -174,7 +204,9 @@ func (app *BaseApp) Query(_ context.Context, req *abci.RequestQuery) (resp *abci
 	// handle gRPC routes first rather than calling splitPath because '/' characters
 	// are used as part of gRPC paths
 	if grpcHandler := app.grpcQueryRouter.Route(req.Path); grpcHandler != nil {
-		return app.handleQueryGRPC(grpcHandler, req), nil
+		// Gonka: handleQueryGRPC populates setup/handler timings + gas onto
+		// gonkaRec, which the deferred observation above reads.
+		return app.handleQueryGRPC(grpcHandler, req, &gonkaRec), nil
 	}
 
 	path := SplitABCIQueryPath(req.Path)
@@ -1149,13 +1181,29 @@ func (app *BaseApp) getContextForProposal(ctx sdk.Context, height int64) sdk.Con
 	return ctx
 }
 
-func (app *BaseApp) handleQueryGRPC(handler GRPCQueryHandler, req *abci.RequestQuery) *abci.ResponseQuery {
+// Gonka: third arg `rec` is optional. When non-nil, the function records the
+// CreateQueryContext duration as setup, the handler invocation duration as
+// handler, and gas consumed. The top-level Query() reads these in its defer.
+func (app *BaseApp) handleQueryGRPC(handler GRPCQueryHandler, req *abci.RequestQuery, rec *gonkaQueryRecord) *abci.ResponseQuery {
+	setupStart := time.Now()
 	ctx, err := app.CreateQueryContext(req.Height, req.Prove)
+	if rec != nil {
+		rec.setupDuration = time.Since(setupStart)
+	}
 	if err != nil {
 		return sdkerrors.QueryResult(err, app.trace)
 	}
 
+	handlerStart := time.Now()
 	resp, err := handler(ctx, req)
+	if rec != nil {
+		rec.handlerDuration = time.Since(handlerStart)
+		if gm := ctx.GasMeter(); gm != nil {
+			rec.gasConsumed = gm.GasConsumed()
+		}
+		rec.requestSummary = fmt.Sprintf("path=%s height=%d data=%dB prove=%v", req.Path, req.Height, len(req.Data), req.Prove)
+	}
+
 	if err != nil {
 		resp = sdkerrors.QueryResult(gRPCErrorToSDKError(err), app.trace)
 		resp.Height = req.Height

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -11,11 +12,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
@@ -38,12 +41,80 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server, skipCheckHeader bool) {
 	// Define an interceptor for all gRPC queries: this interceptor will create
 	// a new sdk.Context, and pass it into the query handler.
-	interceptor := func(grpcCtx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	interceptor := func(grpcCtx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		// Gonka: query telemetry. Two layers:
+		//  - go-metrics counters (`query_count`, `query_<method>`) preserved
+		//    for backward compatibility with the existing telemetry series.
+		//  - gonka_query_* Prometheus metrics with method/status/transport
+		//    labels, registered in query_metrics.go. Slow queries above the
+		//    GONKA_SLOW_QUERY_THRESHOLD_MS threshold also emit a structured
+		//    log line carrying request summary + peer.
+		method := info.FullMethod
+		transport := GonkaTransportGRPC
+
 		// If there's some metadata in the context, retrieve it.
 		md, ok := metadata.FromIncomingContext(grpcCtx)
 		if !ok {
 			return nil, status.Error(codes.Internal, "unable to retrieve metadata")
 		}
+
+		// Gonka: REST traffic flows through grpc-gateway and arrives here as a
+		// gRPC call carrying `grpcgateway-*` forwarded headers.
+		if len(md.Get("grpcgateway-user-agent")) > 0 {
+			transport = GonkaTransportREST
+		}
+
+		// Gonka: peer attribution (bucketed by /24 or /48 to bound cardinality).
+		peerLabel := GonkaPeerUnknown
+		if p, pok := peer.FromContext(grpcCtx); pok && p.Addr != nil {
+			peerLabel = gonkaSanitizePeer(p.Addr.String())
+		}
+
+		telemetry.IncrCounter(1, "query", "count")
+		telemetry.IncrCounter(1, "query", method)
+		defer telemetry.MeasureSince(telemetry.Now(), method)
+
+		gonkaQueryInFlight.WithLabelValues(method, transport).Inc()
+		defer gonkaQueryInFlight.WithLabelValues(method, transport).Dec()
+
+		var (
+			sdkCtx          sdk.Context
+			sdkCtxValid     bool
+			requestedHeight int64
+			start           = time.Now()
+			setupDuration   time.Duration
+			handlerStart    time.Time
+			handlerDuration time.Duration
+		)
+
+		// Gonka: deferred metrics observation. Added before the recovery defer
+		// below so it pops second (LIFO) and observes post-recovery err.
+		defer func() {
+			rec := gonkaQueryRecord{
+				method:          method,
+				transport:       transport,
+				status:          gonkaClassifyGRPCErr(err),
+				peer:            peerLabel,
+				start:           start,
+				setupDuration:   setupDuration,
+				handlerDuration: handlerDuration,
+				totalDuration:   time.Since(start),
+				respBytes:       -1,
+				requestedHeight: requestedHeight,
+				currentHeight:   app.LastBlockHeight(),
+				requestSummary:  fmt.Sprintf("%v", req),
+			}
+			if s, sok := resp.(interface{ Size() int }); sok {
+				rec.respBytes = s.Size()
+			}
+			if sdkCtxValid {
+				if gm := sdkCtx.GasMeter(); gm != nil {
+					rec.gasConsumed = gm.GasConsumed()
+				}
+			}
+			gonkaObserve(rec)
+			gonkaMaybeSlowLog(app.logger, rec)
+		}()
 
 		// Get height header from the request context, if present.
 		var height int64
@@ -58,13 +129,17 @@ func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server
 				return nil, err
 			}
 		}
+		requestedHeight = height
 
-		// Create the sdk.Context. Passing false as 2nd arg, as we can't
-		// actually support proofs with gRPC right now.
-		sdkCtx, err := app.CreateQueryContextWithCheckHeader(height, false, !skipCheckHeader)
+		// Gonka: time the sdk.Context construction. Commit-phase blocking
+		// shows up here, not in the handler.
+		setupStart := time.Now()
+		sdkCtx, err = app.CreateQueryContextWithCheckHeader(height, false, !skipCheckHeader)
+		setupDuration = time.Since(setupStart)
 		if err != nil {
 			return nil, err
 		}
+		sdkCtxValid = true
 
 		// Add relevant gRPC headers
 		if height == 0 {
@@ -93,7 +168,10 @@ func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server
 			}
 		}()
 
-		return handler(grpcCtx, req)
+		handlerStart = time.Now()
+		resp, err = handler(grpcCtx, req)
+		handlerDuration = time.Since(handlerStart)
+		return resp, err
 	}
 
 	// Loop through all services and methods, add the interceptor, and register

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -90,6 +90,11 @@ func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server
 		// Gonka: deferred metrics observation. Added before the recovery defer
 		// below so it pops second (LIFO) and observes post-recovery err.
 		defer func() {
+			totalDuration := time.Since(start)
+			requestSummary := fmt.Sprintf("%T", req)
+			if threshold := gonkaSlowQueryThresholdMs.Load(); threshold > 0 && totalDuration.Milliseconds() >= threshold {
+				requestSummary = fmt.Sprintf("%v", req)
+			}
 			rec := gonkaQueryRecord{
 				method:          method,
 				transport:       transport,
@@ -98,11 +103,11 @@ func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server
 				start:           start,
 				setupDuration:   setupDuration,
 				handlerDuration: handlerDuration,
-				totalDuration:   time.Since(start),
+				totalDuration:   totalDuration,
 				respBytes:       -1,
 				requestedHeight: requestedHeight,
 				currentHeight:   app.LastBlockHeight(),
-				requestSummary:  fmt.Sprintf("%v", req),
+				requestSummary:  requestSummary,
 			}
 			if s, sok := resp.(interface{ Size() int }); sok {
 				rec.respBytes = s.Size()

--- a/baseapp/query_metrics.go
+++ b/baseapp/query_metrics.go
@@ -225,7 +225,7 @@ type gonkaQueryRecord struct {
 	requestSummary  string
 }
 
-// gonkaObserve records all six Prometheus metrics in one place.
+// gonkaObserve records all query Prometheus metrics in one place.
 func gonkaObserve(r gonkaQueryRecord) {
 	if r.totalDuration == 0 {
 		r.totalDuration = time.Since(r.start)

--- a/baseapp/query_metrics.go
+++ b/baseapp/query_metrics.go
@@ -1,0 +1,291 @@
+package baseapp
+
+// Gonka: comprehensive Prometheus metrics and slow-query log for state queries.
+// These complement the existing go-metrics counters (`query_count`,
+// `query_<method>`) and provide labelled histograms suitable for
+// cross-node aggregation in Prometheus.
+//
+// The interceptor in grpcserver.go and the ABCI Query path in abci.go
+// both record into these vectors; transport label distinguishes them.
+//
+// Tag with // Gonka: so future SDK rebases don't silently drop them.
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+const (
+	gonkaQueryNamespace = "gonka"
+	gonkaQuerySubsystem = "query"
+
+	GonkaTransportGRPC = "grpc"
+	GonkaTransportREST = "rest"
+	GonkaTransportABCI = "abci"
+
+	GonkaPeerABCI     = "abci-internal"
+	GonkaPeerUnknown  = "unknown"
+	GonkaPeerOverflow = "overflow"
+
+	gonkaPeerCardinalityCap = 256
+)
+
+var (
+	gonkaQueryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "total",
+		Help:      "Total number of state queries by method, status, and transport.",
+	}, []string{"method", "status", "transport"})
+
+	gonkaQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "duration_seconds",
+		Help:      "End-to-end latency of state queries in seconds (setup + handler).",
+		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+	}, []string{"method", "status", "transport"})
+
+	gonkaQuerySetupDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "setup_duration_seconds",
+		Help:      "Time spent constructing the query context (commit-phase blocking shows here).",
+		Buckets:   []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5},
+	}, []string{"method", "transport"})
+
+	gonkaQueryHandlerDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "handler_duration_seconds",
+		Help:      "Time spent inside the query handler proper (state work).",
+		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+	}, []string{"method", "status", "transport"})
+
+	gonkaQueryResponseBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "response_bytes",
+		Help:      "Response size distribution of state queries in bytes (64 B -> 64 MB).",
+		Buckets:   prometheus.ExponentialBuckets(64, 4, 11),
+	}, []string{"method", "status", "transport"})
+
+	gonkaQueryInFlight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "in_flight",
+		Help:      "Number of currently in-flight state queries.",
+	}, []string{"method", "transport"})
+
+	gonkaQueryGasUsed = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "gas_used",
+		Help:      "Gas consumed by query handlers (internal SDK accounting; not billed). 1k -> 5G.",
+		Buckets:   []float64{1e3, 1e4, 5e4, 1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 5e9},
+	}, []string{"method", "status", "transport"})
+
+	gonkaQueryHeightLag = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "height_lag_blocks",
+		Help:      "Difference between current chain height and queried height. 0 = latest.",
+		Buckets:   []float64{0, 1, 10, 100, 1000, 10000, 100000, 1000000},
+	}, []string{"method"})
+
+	gonkaQueryByPeer = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "by_peer_total",
+		Help:      "Query rate by peer subnet. IPs are bucketed (IPv4 /24, IPv6 /48); cardinality capped at " + strconv.Itoa(gonkaPeerCardinalityCap) + ".",
+	}, []string{"peer", "transport"})
+
+	gonkaQuerySlow = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: gonkaQueryNamespace,
+		Subsystem: gonkaQuerySubsystem,
+		Name:      "slow_total",
+		Help:      "Number of queries that exceeded the slow-query threshold and were logged.",
+	}, []string{"method", "transport"})
+)
+
+// Gonka: slow-query threshold in milliseconds. Read once from env at init,
+// stored as atomic so operators can adjust at runtime if a control surface is
+// wired in later. 0 disables slow-query logging.
+var gonkaSlowQueryThresholdMs atomic.Int64
+
+func init() {
+	v := os.Getenv("GONKA_SLOW_QUERY_THRESHOLD_MS")
+	if v == "" {
+		gonkaSlowQueryThresholdMs.Store(500)
+		return
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || parsed < 0 {
+		gonkaSlowQueryThresholdMs.Store(500)
+		return
+	}
+	gonkaSlowQueryThresholdMs.Store(parsed)
+}
+
+// gonkaPeerSet bounds the cardinality of the peer label. Once the cap is hit,
+// further new peers collapse into GonkaPeerOverflow. This is a one-shot bound;
+// no eviction. Restart the node to reset.
+var (
+	gonkaPeerMu  sync.RWMutex
+	gonkaPeerSet = make(map[string]struct{}, gonkaPeerCardinalityCap)
+)
+
+// gonkaSanitizePeer extracts the bucketed network from a "host:port" peer
+// string and applies the cardinality cap. IPv4 -> /24, IPv6 -> /48.
+func gonkaSanitizePeer(addr string) string {
+	if addr == "" {
+		return GonkaPeerUnknown
+	}
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return GonkaPeerUnknown
+	}
+	var bucket string
+	if ip4 := ip.To4(); ip4 != nil {
+		bucket = fmt.Sprintf("%d.%d.%d.0/24", ip4[0], ip4[1], ip4[2])
+	} else {
+		mask := net.CIDRMask(48, 128)
+		bucket = (&net.IPNet{IP: ip.Mask(mask), Mask: mask}).String()
+	}
+
+	gonkaPeerMu.RLock()
+	_, ok := gonkaPeerSet[bucket]
+	gonkaPeerMu.RUnlock()
+	if ok {
+		return bucket
+	}
+
+	gonkaPeerMu.Lock()
+	defer gonkaPeerMu.Unlock()
+	if _, ok := gonkaPeerSet[bucket]; ok {
+		return bucket
+	}
+	if len(gonkaPeerSet) >= gonkaPeerCardinalityCap {
+		return GonkaPeerOverflow
+	}
+	gonkaPeerSet[bucket] = struct{}{}
+	return bucket
+}
+
+// gonkaClassifyGRPCErr maps a gRPC handler error to a stable status label.
+func gonkaClassifyGRPCErr(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if s, ok := grpcstatus.FromError(err); ok {
+		return s.Code().String()
+	}
+	return grpccodes.Unknown.String()
+}
+
+// gonkaClassifyABCICode maps an ABCI ResponseQuery code to a status label.
+func gonkaClassifyABCICode(code uint32) string {
+	if code == 0 {
+		return "ok"
+	}
+	return fmt.Sprintf("code_%d", code)
+}
+
+// gonkaQueryRecord holds the fields needed to record query metrics and
+// optionally emit a slow-query log line.
+type gonkaQueryRecord struct {
+	method          string
+	transport       string
+	status          string
+	peer            string
+	start           time.Time
+	setupDuration   time.Duration
+	handlerDuration time.Duration
+	totalDuration   time.Duration
+	respBytes       int
+	gasConsumed     uint64
+	requestedHeight int64
+	currentHeight   int64
+	requestSummary  string
+}
+
+// gonkaObserve records all six Prometheus metrics in one place.
+func gonkaObserve(r gonkaQueryRecord) {
+	if r.totalDuration == 0 {
+		r.totalDuration = time.Since(r.start)
+	}
+
+	gonkaQueryTotal.WithLabelValues(r.method, r.status, r.transport).Inc()
+	gonkaQueryDuration.WithLabelValues(r.method, r.status, r.transport).Observe(r.totalDuration.Seconds())
+	if r.setupDuration > 0 {
+		gonkaQuerySetupDuration.WithLabelValues(r.method, r.transport).Observe(r.setupDuration.Seconds())
+	}
+	if r.handlerDuration > 0 {
+		gonkaQueryHandlerDuration.WithLabelValues(r.method, r.status, r.transport).Observe(r.handlerDuration.Seconds())
+	}
+	if r.respBytes >= 0 {
+		gonkaQueryResponseBytes.WithLabelValues(r.method, r.status, r.transport).Observe(float64(r.respBytes))
+	}
+	if r.gasConsumed > 0 {
+		gonkaQueryGasUsed.WithLabelValues(r.method, r.status, r.transport).Observe(float64(r.gasConsumed))
+	}
+	lag := int64(0)
+	if r.requestedHeight > 0 && r.currentHeight > r.requestedHeight {
+		lag = r.currentHeight - r.requestedHeight
+	}
+	gonkaQueryHeightLag.WithLabelValues(r.method).Observe(float64(lag))
+	if r.peer != "" {
+		gonkaQueryByPeer.WithLabelValues(r.peer, r.transport).Inc()
+	}
+}
+
+// gonkaTruncate keeps log lines compact.
+func gonkaTruncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}
+
+// gonkaMaybeSlowLog emits a structured slow-query log line if the threshold
+// is set and exceeded. Threshold == 0 disables.
+func gonkaMaybeSlowLog(logger log.Logger, r gonkaQueryRecord) {
+	threshold := gonkaSlowQueryThresholdMs.Load()
+	if threshold <= 0 {
+		return
+	}
+	if r.totalDuration.Milliseconds() < threshold {
+		return
+	}
+	gonkaQuerySlow.WithLabelValues(r.method, r.transport).Inc()
+	logger.Warn("slow query",
+		"method", r.method,
+		"transport", r.transport,
+		"status", r.status,
+		"duration_ms", r.totalDuration.Milliseconds(),
+		"setup_ms", r.setupDuration.Milliseconds(),
+		"handler_ms", r.handlerDuration.Milliseconds(),
+		"gas_used", r.gasConsumed,
+		"response_bytes", r.respBytes,
+		"requested_height", r.requestedHeight,
+		"current_height", r.currentHeight,
+		"peer", r.peer,
+		"request", strings.TrimSpace(gonkaTruncate(r.requestSummary, 512)),
+	)
+}

--- a/baseapp/query_metrics_test.go
+++ b/baseapp/query_metrics_test.go
@@ -1,0 +1,77 @@
+package baseapp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func resetGonkaPeerSet(t *testing.T) {
+	t.Helper()
+
+	gonkaPeerMu.Lock()
+	defer gonkaPeerMu.Unlock()
+	gonkaPeerSet = make(map[string]struct{}, gonkaPeerCardinalityCap)
+}
+
+func TestGonkaSanitizePeer(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "empty",
+			addr: "",
+			want: GonkaPeerUnknown,
+		},
+		{
+			name: "invalid host",
+			addr: "not-an-ip:1234",
+			want: GonkaPeerUnknown,
+		},
+		{
+			name: "ipv4 host port",
+			addr: "203.0.113.42:26657",
+			want: "203.0.113.0/24",
+		},
+		{
+			name: "ipv4 host only",
+			addr: "198.51.100.7",
+			want: "198.51.100.0/24",
+		},
+		{
+			name: "bracketed ipv6 host port",
+			addr: "[2001:db8:abcd:1234::1]:26657",
+			want: "2001:db8:abcd::/48",
+		},
+		{
+			name: "ipv6 host only",
+			addr: "2001:db8:ffff:1234::1",
+			want: "2001:db8:ffff::/48",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGonkaPeerSet(t)
+			require.Equal(t, tt.want, gonkaSanitizePeer(tt.addr))
+		})
+	}
+}
+
+func TestGonkaSanitizePeerCardinalityCap(t *testing.T) {
+	resetGonkaPeerSet(t)
+
+	for i := 0; i < gonkaPeerCardinalityCap; i++ {
+		addr := fmt.Sprintf("10.%d.%d.1:26657", i/256, i%256)
+		want := fmt.Sprintf("10.%d.%d.0/24", i/256, i%256)
+		require.Equal(t, want, gonkaSanitizePeer(addr))
+	}
+
+	require.Equal(t, GonkaPeerOverflow, gonkaSanitizePeer("172.16.0.1:26657"))
+
+	// Existing buckets continue to resolve even after the cap has been reached.
+	require.Equal(t, "10.0.0.0/24", gonkaSanitizePeer("10.0.0.9:26657"))
+}


### PR DESCRIPTION
Cherry picks new prometheus metrics introduced in `ps-17-observability` into `ps-19`